### PR TITLE
feat: alternate AM key

### DIFF
--- a/config/config.default.json
+++ b/config/config.default.json
@@ -6,6 +6,7 @@
   "show_initial_entries": true,
   "fullscreen": false,
   "disable_activation_mode": false,
+  "am_key": "control",
   "search": {
     "delay": 0,
     "hide_icons": false

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	DisableActivationMode bool      `json:"disable_activation_mode,omitempty"`
 	Clipboard             Clipboard `json:"clipboard,omitempty"`
 	Runner                Runner    `json:"runner,omitempty"`
+	AMKey                 string    `json:"am_key,omitempty"`
 }
 
 type Clipboard struct {

--- a/ui/interactions.go
+++ b/ui/interactions.go
@@ -22,6 +22,8 @@ import (
 var (
 	keys              map[uint]uint
 	activationEnabled bool
+	amKey             uint
+	amModifier        gdk.ModifierType
 )
 
 func setupInteractions(appstate *state.AppState) {
@@ -87,6 +89,18 @@ func setupInteractions(appstate *state.AppState) {
 
 		ui.list.AddController(listkc)
 	}
+
+	switch cfg.AMKey {
+	case "control":
+		amKey = gdk.KEY_Control_L
+		amModifier = gdk.ControlMask
+	case "alt":
+		amKey = gdk.KEY_Alt_L
+		amModifier = gdk.AltMask
+	default:
+		amKey = gdk.KEY_Control_L
+		amModifier = gdk.ControlMask
+	}
 }
 
 func selectNext() {
@@ -151,7 +165,7 @@ func handleListKeysPressed(val uint, code uint, modifier gdk.ModifierType) bool 
 		disabledAM()
 	case gdk.KEY_j, gdk.KEY_k, gdk.KEY_l, gdk.KEY_semicolon, gdk.KEY_a, gdk.KEY_s, gdk.KEY_d, gdk.KEY_f:
 		if !cfg.DisableActivationMode {
-			if modifier == gdk.ControlMask {
+			if modifier == amModifier {
 				selectActivationMode(val, true)
 			} else {
 				selectActivationMode(val, false)
@@ -166,7 +180,7 @@ func handleListKeysPressed(val uint, code uint, modifier gdk.ModifierType) bool 
 
 func handleSearchKeysPressed(val uint, code uint, modifier gdk.ModifierType) bool {
 	if !cfg.DisableActivationMode && ui.selection.NItems() != 0 {
-		if val == gdk.KEY_Control_L {
+		if val == amKey {
 			c := ui.appwin.CSSClasses()
 			c = append(c, "activation")
 			ui.appwin.SetCSSClasses(c)


### PR DESCRIPTION
Adds a config options "am_key" that lets you change the modifier key used for activation mode. This patch lets you use control or alt.

#10 