### PR TITLE
nix: added home manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,52 @@ arch:
 yay -S walker
 ```
 
+<details>
+<summary>Install using nix</summary>
+
+You have two options of installing walker using nix.
+1. Using the package exposed by this flake
+	1. Add to your flake `inputs.walker.url = "github:abenz1267/walker";`
+	2. Add `inputs.walker.packages.<system>.default` to `environment.systemPackages` or `home.packages`
+
+2. Using the home-manager module exposed by this flake
+	1. Add to your flake `inputs.walker.url = "github:abenz1267/walker";`
+	2. Add `imports = [inputs.walker.homeManagerModules.walker];` into your home-manager config
+	3. Configure walker using:
+	```nix
+      programs.walker = {
+        enabled = true;
+        runAsService = true;
+
+        # All options from the config.json can be used here.
+        config = {
+          placeholder = "Example";
+          fullscreen = true;
+          list = {
+            height = 200;
+          };
+          modules = [
+            {
+              name = "websearch";
+              prefix = "?";
+            }
+            {
+              name = "switcher";
+              prefix = "/";
+            }
+          ];
+        };
+
+        # If this is not set the default styling is used.
+        style = ''
+          * {
+            color: #dcd7ba;
+          }
+        '';
+      };
+	```
+</details>
+
 ## Config & Style
 
 Default config will be put into `$HOME/.config/walker/`.

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,11 @@
         };
       };
 
-      # flake = {};
+      flake = {
+        homeManagerModules = rec {
+          walker = import ./nix/hm-module.nix inputs;
+          default = walker;
+        };
+      };
     };
 }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,53 @@
+inputs: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (pkgs.stdenv.hostPlatform) system;
+  defaultConfig = builtins.fromJSON (builtins.readFile ../config/config.default.json);
+  defaultStyle = builtins.readFile ../ui/themes/style.default.css;
+  cfg = config.programs.walker;
+in {
+  options = {
+    programs.walker = with lib; {
+      enabled = mkEnableOption "Enable walker";
+      runAsService = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Run as service";
+      };
+      style = mkOption {
+        type = types.str;
+        default = defaultStyle;
+        description = "Theming";
+      };
+      config = mkOption {
+        type = types.attrs;
+        default = defaultConfig;
+        description = "Configuration";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enabled {
+    home.packages = [inputs.self.packages.${system}.walker];
+
+    xdg.configFile."walker/config.json".text = builtins.toJSON (defaultConfig // config.programs.walker.config);
+    xdg.configFile."walker/style.css".text = config.programs.walker.style;
+
+    systemd.user.services.walker = lib.mkIf cfg.runAsService {
+      Unit = {
+        Description = "Walker - Application Runner";
+      };
+      Install = {
+        WantedBy = [
+          "graphical-session.target"
+        ];
+      };
+      Service = {
+        ExecStart = "${inputs.self.packages.${system}.walker}/bin/walker --gapplication-service";
+      };
+    };
+  };
+}


### PR DESCRIPTION
I have added a home-manager module for nix to make configuring in nix easier.

The config.json file gets automatically merged into the nix config so there is no need to update anything in nix whenever something in the config changes.

I could add a normal nixos module if there is any reason to install this program globally, though you would not be able to configure it due to the config directory being in userspace, but im not sure if this makes sense.

I have moved this module into a nix folder because the base directory is getting cluttered with nix files.
It might make sense to move more files into this directory.
I will create an issue to ask the other nix maintainer in this repo what they think. :)


