### PR TITLE
nix: change enabled option to enable

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -9,9 +9,12 @@ inputs: {
   defaultStyle = builtins.readFile ../ui/themes/style.default.css;
   cfg = config.programs.walker;
 in {
+  imports = [
+    (lib.mkRenamedOptionModule [ "programs" "walker" "enabled" ] [ "programs" "walker" "enable" ])
+  ];
   options = {
     programs.walker = with lib; {
-      enabled = mkEnableOption "Enable walker";
+      enable = mkEnableOption "walker";
       runAsService = mkOption {
         type = types.bool;
         default = false;


### PR DESCRIPTION
Very minor changes to home-manager module. Enabled was changed to enable to be consistent with home-manager and nixpkgs options. The description was changed to because mkEnableOption adds "Enable" to the beginning of the description automatically.