### PR TITLE
nix: updated use of enabled to enable

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -33,7 +33,7 @@ in {
     };
   };
 
-  config = lib.mkIf cfg.enabled {
+  config = lib.mkIf cfg.enable {
     home.packages = [inputs.self.packages.${system}.walker];
 
     xdg.configFile."walker/config.json".text = builtins.toJSON (lib.recursiveUpdate defaultConfig config.programs.walker.config);


### PR DESCRIPTION
silly mistake I made in #18 which is causing a warning to be shown when using the module