### PR TITLE
Nix-related fixes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,10 @@ buildGoModule {
   pname = "walker";
   version = lib.fileContents ./version.txt;
 
-  src = ./.;
+  src = builtins.path {
+    name = "walker-source";
+    path = ./.;
+  };
   vendorHash = "sha256-KvFv3NMYYjPu4PjadWGW44yCSwqElUUTjkEZkUlEFag=";
 
   nativeBuildInputs = [

--- a/default.nix
+++ b/default.nix
@@ -10,6 +10,7 @@
   graphene,
   cairo,
   pango,
+  wrapGAppsHook,
 }:
 buildGoModule {
   pname = "walker";
@@ -18,10 +19,14 @@ buildGoModule {
   src = ./.;
   vendorHash = "sha256-KvFv3NMYYjPu4PjadWGW44yCSwqElUUTjkEZkUlEFag=";
 
-  nativeBuildInputs = [pkg-config];
+  nativeBuildInputs = [
+    gobject-introspection
+    pkg-config
+    wrapGAppsHook
+  ];
+
   buildInputs = [
     glib
-    gobject-introspection
     gtk4
     gtk4-layer-shell
     gdk-pixbuf

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,14 @@
   buildGoModule,
   lib,
   pkg-config,
-  dependencies,
+  glib,
+  gobject-introspection,
+  gtk4,
+  gtk4-layer-shell,
+  gdk-pixbuf,
+  graphene,
+  cairo,
+  pango,
 }:
 buildGoModule {
   pname = "walker";
@@ -12,7 +19,16 @@ buildGoModule {
   vendorHash = "sha256-KvFv3NMYYjPu4PjadWGW44yCSwqElUUTjkEZkUlEFag=";
 
   nativeBuildInputs = [pkg-config];
-  buildInputs = dependencies;
+  buildInputs = [
+    glib
+    gobject-introspection
+    gtk4
+    gtk4-layer-shell
+    gdk-pixbuf
+    graphene
+    cairo
+    pango
+  ];
 
   meta = with lib; {
     description = "Wayland-native application runner";

--- a/flake.nix
+++ b/flake.nix
@@ -18,27 +18,17 @@
         system,
         ...
       }: let
-        inherit (pkgs) callPackage;
+        callPackage = pkgs.lib.callPackageWith (pkgs // packages);
 
-        dependencies = with pkgs; [
-          glib
-          gobject-introspection
-          gtk4
-          gtk4-layer-shell
-          gdk-pixbuf
-          graphene
-          cairo
-          pango
-        ];
+        packages = {
+          walker = callPackage ./. {};
+        };
       in {
         formatter = pkgs.alejandra;
 
-        devShells.default = callPackage ./shell.nix {inherit dependencies;};
+        devShells.default = callPackage ./shell.nix {};
 
-        packages = rec {
-          default = callPackage ./. {inherit dependencies;};
-          walker = default;
-        };
+        packages = packages // {default = packages.walker;};
       };
 
       flake = {

--- a/shell.nix
+++ b/shell.nix
@@ -1,15 +1,7 @@
 {
   mkShell,
-  go,
-  pkg-config,
-  dependencies,
+  walker,
 }:
 mkShell {
-  packages =
-    [
-      # Build
-      go
-      pkg-config
-    ]
-    ++ dependencies;
+  inputsFrom = [walker];
 }


### PR DESCRIPTION
Changes:

- correct `callPackage` misuse
- wrap walker (fixes #25)
- use reproducible source path (see https://nix.dev/guides/best-practices#reproducible-source-paths)

Also, heads up that I noticed that `vendorHash` is set for the package, which would need to be updated if the go dependencies change.
(Alternatively it could be set to `null`, but that'd require vendoring the deps.)

