### PR TITLE
Fix/Respect quotes and escaped characters when parsing shell commands

### DIFF
--- a/modules/external.go
+++ b/modules/external.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/abenz1267/walker/config"
+	"github.com/abenz1267/walker/util"
 )
 
 type External struct {
@@ -66,9 +67,8 @@ func (e External) Entries(ctx context.Context, term string) []Entry {
 	e.src = strings.ReplaceAll(e.src, "%TERM%", term)
 
 	if e.transform {
-		fields := strings.Fields(e.src)
-
-		cmd := exec.Command(fields[0], fields[1:]...)
+		name, args := util.ParseShellCommand(e.src)
+		cmd := exec.Command(name, args...)
 
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -96,10 +96,10 @@ func (e External) Entries(ctx context.Context, term string) []Entry {
 		return entries
 	}
 
-	fields := strings.Fields(e.src)
-	fields = append(fields, term)
+	name, args := util.ParseShellCommand(e.src)
+	args = append(args, term)
 
-	cmd := exec.Command(fields[0], fields[1:]...)
+	cmd := exec.Command(name, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Println(err)

--- a/ui/interactions.go
+++ b/ui/interactions.go
@@ -411,26 +411,26 @@ func activateItem(keepOpen, selectNext bool) {
 		}
 	}
 
-	f := strings.Fields(entry.Exec)
+	name, args := util.ParseShellCommand(entry.Exec)
 
 	if len(entry.RawExec) > 0 {
-		f = entry.RawExec
+		name, args = entry.RawExec[0], entry.RawExec[1:]
 	}
 
-	if len(f) == 0 {
+	if len(name) == 0 {
 		return
 	}
 
 	if cfg.Terminal != "" {
 		if entry.Terminal || forceTerminal {
-			f = append([]string{cfg.Terminal, "-e"}, f...)
+			args = append([]string{cfg.Terminal, "-e"}, args...)
 		}
 	} else {
 		log.Println("terminal is not set")
 		return
 	}
 
-	cmd := exec.Command(f[0])
+	cmd := exec.Command(name)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setsid: true,
 		// Setpgid:    true,
@@ -450,8 +450,8 @@ func activateItem(keepOpen, selectNext bool) {
 		}
 	}
 
-	if len(f) > 1 {
-		cmd = exec.Command(f[0], f[1:]...)
+	if len(args) != 0 {
+		cmd = exec.Command(name, args...)
 	}
 
 	if entry.History {

--- a/util/shell.go
+++ b/util/shell.go
@@ -1,38 +1,41 @@
 package util
 
 import (
-	"strings"
+	"unicode"
 )
 
-func ParseShellCommand(command string) (string, []string) {
-	f := strings.Fields(command)
-	args := parseArgs(f)
+func ParseShellCommand(cmd string) (string, []string) {
+	words := []string{}
 
-	return args[0], args[1:]
-}
-
-func parseArgs(args []string) []string {
-	if len(args) == 0 {
-		return []string{}
-	}
-
-	arg := args[0]
-	i := 1
-	for ; i < len(args); i++ {
-		startsWithQuote := (strings.HasPrefix(arg, "\"") || strings.HasPrefix(arg, "'")) && 
-			!(strings.HasPrefix(arg, "\\\"") || strings.HasPrefix(arg, "\\'"))
-	
-		endsWithQuote := (strings.HasSuffix(arg, "\"") || strings.HasSuffix(arg, "'")) && 
-			!(strings.HasSuffix(arg, "\\\"") || strings.HasSuffix(arg, "\\'"))
-	
-		endsWithBackslash := strings.HasSuffix(arg, "\\")
-
-		if (!startsWithQuote || endsWithQuote) && !endsWithBackslash {
-			break
+	currentWord := ""
+	isEscaped := false
+	isQuote := false
+	for _, c := range cmd {
+		if isEscaped {
+			currentWord += string(c)
+			isEscaped = false
+			continue
 		}
 
-		arg += " " + args[i]
-	}
+		if c == '\\' {
+			isEscaped = true
+			continue
+		} 
 
-	return append([]string{arg}, parseArgs(args[i:])...)
+		if c == '"' || c == '\'' {
+			isQuote = !isQuote
+			continue
+		}
+
+		if unicode.IsSpace(c) && !isQuote {
+			words = append(words, currentWord)
+			currentWord = ""
+			continue
+		}
+
+		currentWord += string(c)
+	}
+	words = append(words, currentWord)
+
+	return words[0], words[1:]
 }

--- a/util/shell.go
+++ b/util/shell.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"strings"
+)
+
+func ParseShellCommand(command string) (string, []string) {
+	f := strings.Fields(command)
+	args := parseArgs(f)
+
+	return args[0], args[1:]
+}
+
+func parseArgs(args []string) []string {
+	if len(args) == 0 {
+		return []string{}
+	}
+
+	arg := args[0]
+	i := 1
+	for ; i < len(args); i++ {
+		startsWithQuote := (strings.HasPrefix(arg, "\"") || strings.HasPrefix(arg, "'")) && 
+			!(strings.HasPrefix(arg, "\\\"") || strings.HasPrefix(arg, "\\'"))
+	
+		endsWithQuote := (strings.HasSuffix(arg, "\"") || strings.HasSuffix(arg, "'")) && 
+			!(strings.HasSuffix(arg, "\\\"") || strings.HasSuffix(arg, "\\'"))
+	
+		endsWithBackslash := strings.HasSuffix(arg, "\\")
+
+		if (!startsWithQuote || endsWithQuote) && !endsWithBackslash {
+			break
+		}
+
+		arg += " " + args[i]
+	}
+
+	return append([]string{arg}, parseArgs(args[i:])...)
+}


### PR DESCRIPTION
Adds a simple parser which respects quoted strings and escaped characters when parsing commands from Exec= fields or the runner.