### PR TITLE
Fix crashing when parsing shell commands

### DIFF
--- a/util/shell.go
+++ b/util/shell.go
@@ -40,6 +40,10 @@ func ParseShellCommand(cmd string) (string, []string) {
 		words = append(words, currentWord)
 	}
 
+	if len(words) == 0 {
+		return "", []string{}
+	}
+
 	return words[0], words[1:]
 }
 


### PR DESCRIPTION
Fix regression introduced by #38. When the parser receives empty or invalid commands, the app crashes with a panic:
> panic: runtime error: slice bounds out of range [1:0]