### PR TITLE
fix: pass pattern to fzf in lowercase

### DIFF
--- a/util/fzf.go
+++ b/util/fzf.go
@@ -1,13 +1,15 @@
 package util
 
 import (
+	"strings"
+
 	"github.com/junegunn/fzf/src/algo"
 	"github.com/junegunn/fzf/src/util"
 )
 
 func FuzzyScore(input, target string) float64 {
 	chars := util.ToChars([]byte(target))
-	res, _ := algo.FuzzyMatchV2(false, true, true, &chars, []rune(input), true, nil)
+	res, _ := algo.FuzzyMatchV2(false, true, true, &chars, []rune(strings.ToLower(input)), true, nil)
 
 	return float64(res.Score)
 }


### PR DESCRIPTION
As stated in the comments to the FuzzyMatchV2 function, the pattern (variable "input" in our case) must be passed in lowercase:
```go
func FuzzyMatchV2(caseSensitive bool, normalize bool, forward bool, input *util.Chars, pattern []rune, withPos bool, slab *util.Slab) (Result, *[]int) {
	// Assume that pattern is given in lowercase if case-insensitive.
```

Otherwise, it will not work correctly and will not match entries when the search input contains uppercase letters. For example, "blender" will work, but "Blender" won't.