### PR TITLE
nix(ci): build default instead of .

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -29,4 +29,4 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build default package
-        run: nix build -L --extra-substituters "https://walker.cachix.org" .
+        run: nix build -L --extra-substituters "https://walker.cachix.org" .#default


### PR DESCRIPTION
No clue what . even builds to be honest. The end result is a bin/cmd which runs walker (???)