### PR TITLE
fix: prevent crashes caused by nil value

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -353,7 +353,9 @@ func setupFactory() *gtk.SignalListItemFactory {
 				ii := val.Icon
 
 				if ii == "" {
-					ii = findModule(val.Module, toUse).General().Icon
+					if m := findModule(val.Module, toUse); m != nil {
+						ii = m.General().Icon
+					}
 				}
 
 				if ii != "" {


### PR DESCRIPTION
Another fix for #98 

But I'm not sure why the value of `val.Module` is empty in the first place.