### PR TITLE
Don't trim whitespaces for clipboard

### DIFF
--- a/internal/modules/clipboard/clipboard.go
+++ b/internal/modules/clipboard/clipboard.go
@@ -128,13 +128,13 @@ func getType() string {
 }
 
 func getContent() (string, string) {
-	cmd := exec.Command("wl-paste")
+	cmd := exec.Command("wl-paste", "-n")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", ""
 	}
 
-	txt := strings.TrimSpace(string(out))
+	txt := string(out)
 	hash := md5.Sum([]byte(txt))
 	strg := hex.EncodeToString(hash[:])
 


### PR DESCRIPTION
Don't trim clipboard copied text. 
Preserve new lines and white spaces.

Will close #117 if merged.