### PR TITLE
feat: add vim-like alternative esc keybinding ctrl+[

### DIFF
--- a/internal/config/config.default.json
+++ b/internal/config/config.default.json
@@ -16,6 +16,7 @@
   "timeout": 0,
   "disable_click_to_close": false,
   "force_keyboard_focus": false,
+  "use_vim_esc_key": false,
   "list": {
     "dynamic_sub": true,
     "keyboard_scroll_style": "emacs",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	ThemeBase           []string       `mapstructure:"theme_base"`
 	Timeout             int            `mapstructure:"timeout"`
 	UseUWSM             bool           `mapstructure:"use_uwsm"`
+	UseVimEscKey        bool           `mapstructure:"use_vim_esc_key"`
 
 	Available []string `mapstructure:"-"`
 	IsService bool     `mapstructure:"-"`

--- a/internal/ui/interactions.go
+++ b/internal/ui/interactions.go
@@ -254,6 +254,18 @@ func disableAM() {
 	}
 }
 
+func handleExitKey() {
+	if appstate.IsDmenu {
+		handleDmenuResult("")
+	}
+
+	if cfg.IsService {
+		quit(false)
+	} else {
+		exit(false)
+	}
+}
+
 func handleGlobalKeysReleased(val, code uint, state gdk.ModifierType) {
 	switch val {
 	case amKey:
@@ -345,17 +357,8 @@ func handleGlobalKeysPressed(val uint, code uint, modifier gdk.ModifierType) boo
 			}
 		}
 	case gdk.KEY_Escape:
-		if appstate.IsDmenu {
-			handleDmenuResult("")
-		}
-
-		if cfg.IsService {
-			quit(false)
-			return true
-		} else {
-			exit(false)
-			return true
-		}
+		handleExitKey()
+		return true
 	case gdk.KEY_F1, gdk.KEY_F2, gdk.KEY_F3, gdk.KEY_F4, gdk.KEY_F5, gdk.KEY_F6, gdk.KEY_F7, gdk.KEY_F8:
 		index := slices.Index(fkeys, val)
 
@@ -465,6 +468,10 @@ func handleGlobalKeysPressed(val uint, code uint, modifier gdk.ModifierType) boo
 					return true
 				}
 			}
+		}
+		if cfg.UseVimEscKey && modifier == gdk.ControlMask && val == gdk.KEY_bracketleft {
+			handleExitKey()
+			return true
 		}
 
 		if !cfg.ActivationMode.Disabled && activationEnabled {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -221,8 +221,7 @@ func setupElementsPassword(app *gtk.Application) *Elements {
 
 	controller := gtk.NewEventControllerKey()
 	controller.ConnectKeyPressed(func(val uint, code uint, modifier gdk.ModifierType) bool {
-		switch val {
-		case gdk.KEY_Escape:
+		if val == gdk.KEY_Escape || (cfg.UseVimEscKey && modifier == gdk.ControlMask && val == gdk.KEY_bracketleft) {
 			elements.appwin.Close()
 			return true
 		}


### PR DESCRIPTION
This allows the user to exit from the application (or just close the UI window in service mode) when the ctrl+[ key binding has been pressed. This to resemble the behavior like in [vim](https://github.com/vim/vim/blob/21c37d7f695077efe6df57806ff35da79adce1d5/runtime/doc/map.txt#L1024) and other applications. Maybe it could be more useful to allow for a custom alternative keybinding but I haven't found an easy way to do so with the gdk library, so I'll leave it for when a global custom keybindings systems would ever be implemented.