### PR TITLE
Fix initial query interactions

### DIFF
--- a/cmd/walker.go
+++ b/cmd/walker.go
@@ -257,8 +257,10 @@ Type=Application
 			state.ExplicitPlaceholder = placeholderString.String()
 		}
 
-		if initialQueryString != nil && initialQueryString.String() != "" {
+		if initialQueryString != nil {
 			state.InitialQuery = initialQueryString.String()
+		} else {
+			state.InitialQuery = ""
 		}
 
 		if configString != nil && configString.String() != "" {

--- a/internal/ui/interactions.go
+++ b/internal/ui/interactions.go
@@ -80,6 +80,8 @@ func setupInteractions(appstate *state.AppState) {
 	go setupCommands()
 	parseKeybinds()
 
+	lastQuery = trimArgumentDelimiter(elements.input.Text())
+
 	elements.input.Connect("changed", func() {
 		text := elements.input.Text()
 


### PR DESCRIPTION
Fixes the problems described in the issue #223 

First commit makes sure that InitialQuery is always cleared. 

The second one set initial value to lastQuery so that the condition is not triggered on the first run.

https://github.com/abenz1267/walker/blob/906c61ad7bac0b2d737cf290d2ee50365a65ce66/internal/ui/interactions.go#L853-L855