### PR TITLE
nix: spring cleaning

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,25 +1,5 @@
 {
   "nodes": {
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1738142207,
@@ -38,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "systems": "systems"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -30,12 +30,17 @@
 
     packages = eachSystem (pkgs: {
       default = self.packages.${pkgs.system}.walker;
-      walker-git = pkgs.callPackage ./nix/package.nix {};
+      walker = pkgs.callPackage ./nix/package.nix {};
     });
 
     homeManagerModules = {
       default = self.homeManagerModules.walker;
-      walker = import ./nix/hm-module.nix self;
+      walker = import ./nix/modules/home-manager.nix self;
+    };
+
+    nixosModules = {
+      default = self.nixosModules.walker;
+      walker = import ./nix/modules/nixos.nix self;
     };
 
     nixConfig = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,41 +1,46 @@
 {
-  description = "Wayland-native application runner";
+  description = ''
+    Multi-Purpose Launcher with a lot of features. Highly Customizable and fast.
+  '';
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-parts = {
-      url = "github:hercules-ci/flake-parts";
-      inputs.nixpkgs-lib.follows = "nixpkgs";
-    };
     systems.url = "github:nix-systems/default-linux";
   };
 
-  outputs = inputs @ {
-    flake-parts,
+  outputs = {
     self,
+    nixpkgs,
     systems,
     ...
-  }:
-    flake-parts.lib.mkFlake {inherit inputs;} {
-      systems = import systems;
+  }: let
+    inherit (nixpkgs) lib;
+    eachSystem = f:
+      lib.genAttrs (import systems)
+      (system: f nixpkgs.legacyPackages.${system});
+  in {
+    formatter = eachSystem (pkgs: pkgs.alejandra);
 
-      perSystem = {pkgs, ...}: let
-        walker = pkgs.callPackage ./nix/package.nix {};
-      in {
-        formatter = pkgs.alejandra;
-
-        devShells.default = pkgs.mkShell { inputsFrom = [walker]; };
-
-        packages.default = walker;
+    devShells = eachSystem (pkgs: {
+      default = pkgs.mkShell {
+        name = "walker";
+        inputsFrom = [self.packages.${pkgs.system}.walker];
       };
+    });
 
-      flake = {
-        homeManagerModules.default = import ./nix/hm-module.nix self;
+    packages = eachSystem (pkgs: {
+      default = self.packages.${pkgs.system}.walker;
+      walker-git = pkgs.callPackage ./nix/package.nix {};
+    });
 
-        nixConfig = {
-          extra-substituters = ["https://walker-git.cachix.org"];
-          extra-trusted-public-keys = ["walker-git.cachix.org-1:vmC0ocfPWh0S/vRAQGtChuiZBTAe4wiKDeyyXM0/7pM="];
-        };
-      };
+    homeManagerModules = {
+      default = self.homeManagerModules.walker;
+      walker = import ./nix/hm-module.nix self;
     };
+
+    nixConfig = {
+      extra-substituters = ["https://walker-git.cachix.org"];
+      extra-trusted-public-keys = ["walker-git.cachix.org-1:vmC0ocfPWh0S/vRAQGtChuiZBTAe4wiKDeyyXM0/7pM="];
+    };
+  };
 }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -28,6 +28,7 @@ self: {
       };
     };
   };
+
   themeName = "home-manager";
 
   cfg = config.programs.walker;

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -4,32 +4,36 @@ self: {
   pkgs,
   ...
 }: let
-  inherit (lib) mkEnableOption mkOption mkPackageOption importTOML mkIf getExe mkForce mkMerge;
-  inherit (lib.types) bool nullOr submodule lines;
+  inherit (lib.modules) mkIf mkDefault mkMerge;
+  inherit (lib.options) mkOption mkEnableOption mkPackageOption;
+  inherit (lib.trivial) importTOML;
+  inherit (lib.meta) getExe;
+  inherit (lib.types) nullOr bool submodule lines;
 
   tomlFormat = pkgs.formats.toml {};
 
-  themeType = submodule {
-    options = {
-      layout = mkOption {
-        inherit (tomlFormat) type;
-        default = {};
-        description = ''
-          The layout of the theme.
+  theme = {
+    name = "nixos";
+    type = submodule {
+      options = {
+        layout = mkOption {
+          inherit (tomlFormat) type;
+          default = {};
+          description = ''
+            The layout of the theme.
 
-          See <https://github.com/abenz1267/walker/wiki/Theming> for the full list of options.
-        '';
-      };
+            See <https://github.com/abenz1267/walker/wiki/Theming> for the full list of options.
+          '';
+        };
 
-      style = mkOption {
-        type = lines;
-        default = "";
-        description = "The styling of the theme, written in GTK CSS.";
+        style = mkOption {
+          type = lines;
+          default = "";
+          description = "The styling of the theme, written in GTK CSS.";
+        };
       };
     };
   };
-
-  themeName = "home-manager";
 
   cfg = config.programs.walker;
 in {
@@ -49,16 +53,17 @@ in {
 
       config = mkOption {
         inherit (tomlFormat) type;
-        default = importTOML ../internal/config/config.default.toml;
+        default = importTOML ../../internal/config/config.default.toml;
+        defaultText = "importTOML ../../internal/config/config.default.toml";
         description = ''
-          Configuration written to `$XDG_CONFIG_HOME/walker/config.toml`.
+          Configuration written to {file}`$XDG_CONFIG_HOME/walker/config.toml`.
 
           See <https://github.com/abenz1267/walker/wiki/Basic-Configuration> for the full list of options.
         '';
       };
 
       theme = mkOption {
-        type = nullOr themeType;
+        type = nullOr theme.type;
         default = null;
         description = "The custom theme used by walker. Setting this option overrides `config.theme`.";
       };
@@ -82,11 +87,11 @@ in {
     }
 
     (mkIf (cfg.theme != null) {
-      programs.walker.config.theme = mkForce themeName;
+      programs.walker.config.theme = mkDefault theme.name;
 
       xdg.configFile = {
-        "walker/themes/${themeName}.toml".source = tomlFormat.generate "walker-themes-${themeName}.toml" cfg.theme.layout;
-        "walker/themes/${themeName}.css".text = cfg.theme.style;
+        "walker/themes/${theme.name}.toml".source = tomlFormat.generate "walker-themes-${theme.name}.toml" cfg.theme.layout;
+        "walker/themes/${theme.name}.css".text = cfg.theme.style;
       };
     })
   ]);

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -1,0 +1,99 @@
+self: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.modules) mkIf mkDefault mkMerge;
+  inherit (lib.options) mkOption mkEnableOption mkPackageOption;
+  inherit (lib.trivial) importTOML;
+  inherit (lib.meta) getExe;
+  inherit (lib.types) nullOr bool lines submodule;
+
+  tomlFormat = pkgs.formats.toml {};
+
+  theme = {
+    name = "nixos";
+    type = submodule {
+      options = {
+        layout = mkOption {
+          inherit (tomlFormat) type;
+          default = {};
+          description = ''
+            The layout of the theme.
+
+            See <https://github.com/abenz1267/walker/wiki/Theming> for the full list of options.
+          '';
+        };
+
+        style = mkOption {
+          type = lines;
+          default = "";
+          description = "The styling of the theme, written in GTK CSS.";
+        };
+      };
+    };
+  };
+
+  cfg = config.programs.walker;
+in {
+  options = {
+    programs.walker = {
+      enable = mkEnableOption "walker";
+      package = mkPackageOption self.packages.${pkgs.system} "walker" {
+        default = "default";
+        pkgsText = "walker.packages.\${pkgs.system}";
+      };
+
+      runAsService = mkOption {
+        type = bool;
+        default = false;
+        description = "Run walker as a service for faster startup times.";
+      };
+
+      config = mkOption {
+        inherit (tomlFormat) type;
+        default = importTOML ../../internal/config/config.default.toml;
+        defaultText = "importTOML ../../internal/config/config.default.toml";
+        description = ''
+          Configuration written to {file}`$XDG_CONFIG_HOME/walker/config.toml`.
+
+          See <https://github.com/abenz1267/walker/wiki/Basic-Configuration> for the full list of options.
+        '';
+      };
+
+      theme = mkOption {
+        type = nullOr theme.type;
+        default = null;
+        description = "The custom theme used by walker. Setting this option overrides `config.theme`.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      environment = {
+        systemPackages = [cfg.package];
+        etc."xdg/walker/config.toml".source = mkIf (cfg.config != {}) (tomlFormat.generate "walker-config.toml" cfg.config);
+      };
+
+      systemd.services.walker = mkIf cfg.runAsService {
+        description = "Walker - Application Runner";
+        wantedBy = ["graphical-session.target"];
+        service = {
+          ExecStart = "${getExe cfg.package} --gapplication-service";
+          Restart = "on-failure";
+        };
+      };
+    }
+
+    (mkIf (cfg.theme != null) {
+      programs.walker.config.theme = mkDefault theme.name;
+
+      environment.etc = {
+        "xdg/walker/themes/${theme.name}.toml".source = tomlFormat.generate "walker-themes-${theme.name}.toml" cfg.theme.layout;
+        "xdg/walker/themes/${theme.name}.css".text = cfg.theme.style;
+      };
+    })
+  ]);
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -48,12 +48,12 @@ buildGoModule {
     vips
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Wayland-native application runner";
     homepage = "https://github.com/abenz1267/walker";
-    license = licenses.mit;
-    maintainers = with maintainers; [diniamo];
-    platforms = platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [diniamo NotAShelf];
+    platforms = lib.platforms.linux;
     mainProgram = "walker";
   };
 }


### PR DESCRIPTION
I know it's not spring, but here it goes anyway.

Notable changes are:

0. Gets rid of flake-parts. It is a good library, but obscenely unnecessary in our case. User does not need this, nor do we. Our flake is simple
1. Adds a NixOS module - this expects configuration under /etc/xdg/walker, as per the XDG spec.
2. Cleans up both NixOS and Home-Manager modules and changes to a bit more pedantic Nix code.
	1. Avoids *forcing* themeName in the configuration so that the user may still point at custom configuration files.
3. Removes `with lib;` from package.

