### PR TITLE
Replace "-sh", "-c" with "env", "-S"

### DIFF
--- a/internal/modules/ai.go
+++ b/internal/modules/ai.go
@@ -269,7 +269,7 @@ func (ai *AI) RunLastMessageInTerminal() {
 	shell := os.Getenv("SHELL")
 
 	toRun := fmt.Sprintf("%s %s -e sh -c \"%s; exec %s\"", ai.terminal, config.Cfg.TerminalTitleFlag, last, shell)
-	cmd := exec.Command("sh", "-c", wrapWithPrefix(toRun))
+	cmd := exec.Command("env", "-S", wrapWithPrefix(toRun))
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid:    true,

--- a/internal/modules/ai.go
+++ b/internal/modules/ai.go
@@ -268,7 +268,7 @@ func (ai *AI) RunLastMessageInTerminal() {
 	last := ai.currentMessages[len(ai.currentMessages)-1].Content
 	shell := os.Getenv("SHELL")
 
-	toRun := fmt.Sprintf("%s %s -e sh -c \"%s; exec %s\"", ai.terminal, config.Cfg.TerminalTitleFlag, last, shell)
+	toRun := fmt.Sprintf("%s %s -e env -S \"%s; exec %s\"", ai.terminal, config.Cfg.TerminalTitleFlag, last, shell)
 	cmd := exec.Command("env", "-S", wrapWithPrefix(toRun))
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/internal/modules/clipboard/clipboard.go
+++ b/internal/modules/clipboard/clipboard.go
@@ -193,7 +193,7 @@ func (c *Clipboard) watch() {
 	go func() {
 		time.Sleep(time.Second * 5)
 
-		cmd := exec.Command("sh", "-c", "wl-paste --watch walker --update-clipboard")
+		cmd := exec.Command("env", "-S", "wl-paste --watch walker --update-clipboard")
 
 		_ = cmd.Run()
 	}()

--- a/internal/modules/plugins.go
+++ b/internal/modules/plugins.go
@@ -169,7 +169,7 @@ func (e Plugin) Entries(term string) []util.Entry {
 			return e.entries
 		}
 
-		cmd := exec.Command("sh", "-c", wrapWithPrefix(src))
+		cmd := exec.Command("env", "-S", wrapWithPrefix(src))
 
 		if !hasExplicitTerm {
 			cmd.Stdin = strings.NewReader(term)
@@ -369,7 +369,7 @@ func (e Plugin) parseJson(out []byte) []util.Entry {
 }
 
 func (e Plugin) getSrcOutput(src string, hasExplicitTerm bool, term string) []byte {
-	cmd := exec.Command("sh", "-c", wrapWithPrefix(src))
+	cmd := exec.Command("env", "-S", wrapWithPrefix(src))
 
 	if !hasExplicitTerm && term != "" {
 		cmd.Stdin = strings.NewReader(term)

--- a/internal/ui/events.go
+++ b/internal/ui/events.go
@@ -13,7 +13,7 @@ func executeEvent(eventType config.EventType, label string) {
 	}
 
 	go func() {
-		cmd := exec.Command("sh", "-c")
+		cmd := exec.Command("env", "-S")
 
 		toRun := ""
 

--- a/internal/ui/interactions.go
+++ b/internal/ui/interactions.go
@@ -71,7 +71,7 @@ func setupCommands() {
 			return false
 		}
 
-		cmd := exec.Command("sh", "-c", wrapWithPrefix(fmt.Sprintf("xdg-open %s", cssFile)))
+		cmd := exec.Command("env", "-S", wrapWithPrefix(fmt.Sprintf("xdg-open %s", cssFile)))
 		cmd.SysProcAttr = &syscall.SysProcAttr{
 			Setpgid:    true,
 			Pgid:       0,
@@ -437,7 +437,7 @@ func activateItem(keepOpen, alt bool) {
 		toRun = fmt.Sprintf("%s %s", toRun, split[1])
 	}
 
-	cmd := exec.Command("sh", "-c", wrapWithPrefix(toRun))
+	cmd := exec.Command("env", "-S", wrapWithPrefix(toRun))
 
 	if entry.Path != "" {
 		cmd.Dir = entry.Path
@@ -1325,7 +1325,7 @@ func executeOnSelect(entry util.Entry) {
 			explicit = true
 		}
 
-		cmd := exec.Command("sh", "-c", toRun)
+		cmd := exec.Command("env", "-S", toRun)
 
 		if !explicit {
 			setStdin(cmd, &util.Piped{String: val, Type: "string"})
@@ -1343,7 +1343,7 @@ func executeOnSelect(entry util.Entry) {
 }
 
 func forceTerminalForFile(file string) bool {
-	cmd := exec.Command("sh", "-c", fmt.Sprintf("xdg-mime query default $(xdg-mime query filetype %s)", file))
+	cmd := exec.Command("env", "-S", fmt.Sprintf("xdg-mime query default $(xdg-mime query filetype %s)", file))
 
 	homedir, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -248,7 +248,7 @@ func setupBarTheme() {
 			controller.SetPropagationPhase(gtk.PropagationPhase(1))
 			controller.Connect("pressed", func(gesture *gtk.GestureClick, n int) {
 				if v.Module == "" && v.Exec != "" {
-					cmd := exec.Command("sh", "-c", wrapWithPrefix(v.Exec))
+					cmd := exec.Command("env", "-S", wrapWithPrefix(v.Exec))
 
 					cmd.SysProcAttr = &syscall.SysProcAttr{
 						Setpgid:    true,

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -613,7 +613,7 @@ func setupFactory() *gtk.SignalListItemFactory {
 
 				run = trimArgumentDelimiter(run)
 
-				cmd := exec.Command("sh", "-c", run)
+				cmd := exec.Command("env", "-S", run)
 
 				out, err := cmd.CombinedOutput()
 				if err != nil {


### PR DESCRIPTION
Trying to get a rid of the `sh -c` wrappers within hyprland session:
- testing a patched hyprland since 0.47.2 -> works [#9403](https://github.com/hyprwm/Hyprland/discussions/9403#discussioncomment-12269295)
- nwg-drawer, nwg-menu already got rid of the `sh -c` wrappings
- now doing the same `env -S` "trick" with walker as my favorite app runner (and more).

As a first step - only the interactions.go file modified and tested - I'm using daily always.. I'll need to check and test the others: events, plugins, ai, clipboard, theme, ui.

Running programs, wayland or xwayland works (Through hyprland-polkit-agent, which adds its own `/bin/sh` wrap, :) )