### PR TITLE
interactions: trim spaces before searching entries

### DIFF
--- a/internal/ui/interactions.go
+++ b/internal/ui/interactions.go
@@ -763,9 +763,9 @@ func processAsync(text string) {
 			}
 
 			text = strings.TrimPrefix(text, w.General().Prefix)
+			text = strings.TrimSpace(text)
 
 			e := w.Entries(text)
-			text = strings.TrimSpace(text)
 
 			toPush := []util.Entry{}
 			g := w.General()


### PR DESCRIPTION
Hi,

I've realized that when your entry is completely empty and you press space, the runtime gets killed with this log;
```
panic: runtime error: index out of range [0] with length 0

goroutine 69 [running]:
github.com/abenz1267/walker/internal/modules.Runner.Entries({{{0x0, {0x0, 0x0, 0x0}, 0x0, 0x1, 0x0, 0x0, 0x1, {0x0, ...}, ...}, ...}, ...}, ...)
        github.com/abenz1267/walker/internal/modules/runner.go:115 +0x7e5
github.com/abenz1267/walker/internal/ui.processAsync.func3(0xc000272010?, {0xc000272000, 0x1}, {0x12253d8, 0xc00019f080})
        github.com/abenz1267/walker/internal/ui/interactions.go:767 +0x16d
created by github.com/abenz1267/walker/internal/ui.processAsync in goroutine 67
        github.com/abenz1267/walker/internal/ui/interactions.go:756 +0x705
```

If we trim spaces before searching the entries--so that `w.Entries` will simply return back nothing--this problem goes away.

Thanks!