### PR TITLE
meta: the nix option for styling walker was moved to `theme.style`

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ programs.walker = {
   };
 
   # If this is not set the default styling is used.
-  style = ''
+  theme.style = ''
     * {
       color: #dcd7ba;
     }


### PR DESCRIPTION
but for some reason the README wasn't updated to reflect this