### PR TITLE
fix(config): remove builtins.hyprland_keybinds.path from default config

### DIFF
--- a/internal/config/config.default.toml
+++ b/internal/config/config.default.toml
@@ -57,7 +57,6 @@ labels = "jkl;asdf"
 
 [builtins.hyprland_keybinds]
 show_sub_when_single = true
-path = "~/.config/hypr/hyprland.conf"
 weight = 5
 name = "hyprland_keybinds"
 placeholder = "Hyprland Keybinds"


### PR DESCRIPTION
Not used because since d6c0b22805794e36eb87276b98b0e6fe080d94f3 hyprland config file isn't parsed and instead binds are queried directly via hyprctl