### PR TITLE
nixos.nix: Fix systemd service declaration

### DIFF
--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -80,7 +80,7 @@ in {
       systemd.services.walker = mkIf cfg.runAsService {
         description = "Walker - Application Runner";
         wantedBy = ["graphical-session.target"];
-        service = {
+        serviceConfig = {
           ExecStart = "${getExe cfg.package} --gapplication-service";
           Restart = "on-failure";
         };


### PR DESCRIPTION
The current NixOS module produces the following error as `systemd.services.<ServiceName>.service` should instead be `systemd.services.<ServiceName>.serviceConfig`[¹](https://search.nixos.org/options?channel=unstable&show=systemd.services.%3Cname%3E.serviceConfig&from=0&size=50&sort=alpha_asc&type=packages&query=systemd.services.) [²](https://github.com/NixOS/nixpkgs/blob/6e987485eb2c77e5dcc5af4e3c70843711ef9251/nixos/modules/system/boot/systemd.nix#L535):
>```
> error: The option `systemd.services.walker.service' does not exist. Definition values:
> 	- In `/nix/store/shcaifi35d3k2dnc6vkgfkihzpycjma7-source/flake.nix':
> 	   {
> 	     ExecStart = "/nix/store/zx1017hdv4cqnf0l76v2qlpspc8aig31-walker-0.13.2-git/bin/walker --gapplication-service";
> 	     Restart = "on-failure";
> 	   }
> ```