### PR TITLE
fix: start timeout timer immediately when window opens

### DIFF
--- a/internal/ui/interactions.go
+++ b/internal/ui/interactions.go
@@ -678,6 +678,9 @@ func timeoutReset() {
 
 func handleTimeout() {
 	if config.Cfg.Timeout > 0 {
+		// Start the timeout timer immediately when window is shown
+		timeoutReset()
+		
 		if appstate.Password {
 			elements.password.Connect("changed", timeoutReset)
 			return


### PR DESCRIPTION
Previously, the timeout timer would only start after user interaction (typing or scrolling). Now it starts as soon as the window appears, ensuring it will close after the configured timeout even if the user never interacts with it.