### PR TITLE
fix: add nil check for clipboard module to prevent panic

### DIFF
--- a/internal/ui/interactions.go
+++ b/internal/ui/interactions.go
@@ -54,6 +54,11 @@ func setupCommands() {
 	}
 	commands["clearclipboard"] = func() bool {
 		m := findModule("clipboard", available)
+
+		if m == nil {
+			return true
+		}
+
 		m.(*clipboard.Clipboard).Clear()
 
 		return true


### PR DESCRIPTION
Prevent panic when findModule returns nil by adding a safety check before attempting to access the clipboard module methods.

Note: findModule calls throughout codebase may need similar nil checks, but keeping fix minimal due to ongoing Rust rewrite (I basically just fixed the only command that caused me a panic).