### PR TITLE
fix: Create walker socket directory if missing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -519,6 +519,10 @@ fn listen_activation_socket(app_clone: Application) {
         .unwrap_or_else(|_| env::temp_dir());
 
     socket_path.push("walker");
+    if !socket_path.exists() {
+        fs::create_dir(&socket_path).unwrap();
+    }
+
     socket_path.push("walker.sock");
 
     let _ = fs::remove_file(&socket_path);


### PR DESCRIPTION
On first run, socket creation could fail if its parent directory doesn't exist. This PR aims to fix that.