### PR TITLE
fix: update elephant dependency to v2.0.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757324547,
-        "narHash": "sha256-tF02X+iIca3/KrO6A6etU2aoAjkSFWtPjXXngncaazA=",
+        "lastModified": 1759675127,
+        "narHash": "sha256-AsYUdOukKNXIu47CpQNJeAccu524sIj9UTuP9Aadycs=",
         "owner": "abenz1267",
         "repo": "elephant",
-        "rev": "8eddcd1fe46159ff25dcdf79b658bc6fa95249fc",
+        "rev": "abfa18c844f1028b0b2beef456fee6d40e98dfad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates elephant flake dependency from v1.0.0-beta-24 to v2.0.0 for compatibility with walker v2.0.0.

This is likely a Nix flake-specific issue where the pinned elephant version in flake.lock was not updated when walker v2.0.0 was released. The outdated elephant causes no applications to appear in the launcher due to incompatible action configuration formats.