### PR TITLE
fix: crash when running walker as a service with custom theme

### DIFF
--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -85,27 +85,27 @@ pub fn setup_themes(elephant: bool, theme: String, is_service: bool) {
             continue;
         }
 
-        let Ok(entries) = fs::read_dir(path) else {
+        let Ok(entries) = fs::read_dir(path.clone()) else {
             continue;
         };
 
         for entry in entries {
             let entry = entry.unwrap();
-            let path = entry.path();
+            let entry_path = entry.path();
 
-            if !path.is_dir() {
+            if !entry_path.is_dir() {
                 continue;
             }
 
-            let Some(name) = path.file_name() else {
+            let Some(name) = entry_path.file_name() else {
                 continue;
             };
 
-            let path_theme = name.to_string_lossy();
+            let theme_name = name.to_string_lossy().to_string();
 
-            if let Some(t) = setup_theme_from_path(path.clone(), &theme, &combined) {
-                themes.insert(path_theme.to_string(), t);
-                add_theme(path_theme.to_string());
+            if let Some(t) = setup_theme_from_path(path.clone(), &theme_name, &combined) {
+                themes.insert(theme_name.clone(), t);
+                add_theme(theme_name);
             }
         }
     }


### PR DESCRIPTION
Related to #536 

When running as a service walker tries to load the theme from `~/.config/walker/themes/<theme_name>/<theme_name>/style.css` instead of `~/.config/walker/themes/<theme_name>/style.css`. The easiest way to test this is by setting a custom theme in `config.toml` creating the relevant  folder and `style.css`. Then adding `let is_service: bool = true;` to the top of the `setup_themes` function to override the default. 

This should probably be refactored further