### PR TITLE
Fix item text wrapping

### DIFF
--- a/resources/themes/default/item.xml
+++ b/resources/themes/default/item.xml
@@ -38,7 +38,7 @@
             <style>
               <class name="item-text"></class>
             </style>
-            <property name="wrap">false</property>
+            <property name="ellipsize">end</property>
             <property name="vexpand_set">true</property>
             <property name="vexpand">true</property>
             <property name="xalign">0</property>
@@ -49,7 +49,7 @@
             <style>
               <class name="item-subtext"></class>
             </style>
-            <property name="wrap">true</property>
+            <property name="ellipsize">end</property>
             <property name="vexpand_set">true</property>
             <property name="vexpand">true</property>
             <property name="xalign">0</property>


### PR DESCRIPTION
Hello,

I have noticed that the text in items is currently not wrapping properly. When the subtext is very long, it pushes the quick activation label out of the viewport, as in the image below:

<img width="627" height="185" alt="2025-10-12-124013_hyprshot" src="https://github.com/user-attachments/assets/66ab9bd4-bef6-468c-a545-63f481b177b5" />

I'm suggesting a fix which will make the layout behave properly, as in the image below:

<img width="577" height="142" alt="2025-10-12-124058_hyprshot" src="https://github.com/user-attachments/assets/5da79b0a-55e7-468e-9d22-540b5807aff1" />

### Details:

- Added ellipsize=end to both the main text and the subtext. This will make the text ellipsize when there is no more room available.
- Set lines=1 and lines=2 on the main text and subtext respectively. This will make the main text ellipsize at the first line break and the subtext at the second one (I'm just assuming 2 lines is good enough, your opinion might differ).
- Set wrap-mode to word-char on both labels (you might prefer char here).
- Set max-width-chars=0 on both labels. I'm honestly not sure why this is working, but without it I can't prevent labels from growing their parent.
- I've set wrap=true on the main text as well, otherwise it doesn't ellipsize. I can't explain this either, sorry.