### PR TITLE
Bugfix: "theme not found. using default theme." when theme exists.

### DIFF
--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -76,22 +76,7 @@ pub fn setup_themes(elephant: bool, theme: String, is_service: bool) {
     };
 
     for config_path in config_paths {
-        if !is_service {
-            let mut path = config_path;
-
-            path.push(&theme);
-
-            if let Some(t) = setup_theme_from_path(path.clone(), &combined) {
-                themes.insert(theme.clone(), t);
-                add_theme(theme.clone());
-            }
-
-            path.pop();
-
-            continue;
-        }
-
-        let Ok(theme_dirs) = fs::read_dir(config_path) else {
+        let Ok(theme_dirs) = fs::read_dir(&config_path) else {
             continue;
         };
 
@@ -113,6 +98,21 @@ pub fn setup_themes(elephant: bool, theme: String, is_service: bool) {
                 themes.insert(theme_name.to_string(), t);
                 add_theme(theme_name.to_string());
             }
+        }
+
+        if !is_service {
+            let mut path = config_path;
+
+            path.push(&theme);
+
+            if let Some(t) = setup_theme_from_path(path.clone(), &combined) {
+                themes.insert(theme.clone(), t);
+                add_theme(theme.clone());
+            }
+
+            path.pop();
+
+            continue;
         }
     }
 


### PR DESCRIPTION
Problem: running commands like `walker --dmenu --theme customtheme` does not find `customtheme` because `setup_themes` keeps looping around a single theme name set from the start (I think it's 'default') and only changing the theme look-in folders.

Solution: force the `theme_dir` loop that checks all theme names to run before so that it adds all the themes found the look-in folders before trying to set it.

Caveats: this might be PEBKAC but I couldn't make it work when trying to have different styles for different kinds of dmenus.


