### PR TITLE
Add dynamic accent color adjustments and handling for theme changes like dark mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -120,11 +120,32 @@ fn init_ui(app: &Application, dmenu: bool) {
 
     let settings = gio::Settings::new("org.gnome.desktop.interface");
     let settings_clone = settings.clone();
+    adjust_accent_color(settings_clone);
+
+
+    let settings_clone = settings.clone();
     adjust_color_scheme(settings_clone);
+
+    let settings_clone = settings.clone();
+    settings.connect_changed(Some("accent-color"), move |_, _| {
+        adjust_accent_color(settings_clone.clone());
+    });
 
     let settings_clone = settings.clone();
     settings.connect_changed(Some("color-scheme"), move |_, _| {
         adjust_color_scheme(settings_clone.clone());
+    });
+}
+
+fn adjust_accent_color(settings: gio::Settings) {
+    with_window(|w| {
+        w.window.css_classes()
+            .iter()
+            .filter(|c| c.starts_with("accent-"))
+            .for_each(|c| w.window.remove_css_class(c));
+
+        let new_accent_color = format!("accent-{}", settings.string("accent-color").as_str());
+        w.window.add_css_class(new_accent_color.as_str());
     });
 }
 


### PR DESCRIPTION
I use Adwaita as my main theme.

To test it, I use the following CSS based on the CSS retrieved via the command `gresource extract /usr/lib/libadwaita-1.so /org/gnome/Adwaita/styles/default.css`:

```css
/* --- Adwaita color support --- */
:root {
    --blue-1: #99c1f1;
    --blue-2: #62a0ea;
    --blue-3: #3584e4;
    --blue-4: #1c71d8;
    --blue-5: #1a5fb4;
    --green-1: #8ff0a4;
    --green-2: #57e389;
    --green-3: #33d17a;
    --green-4: #2ec27e;
    --green-5: #26a269;
    --yellow-1: #f9f06b;
    --yellow-2: #f8e45c;
    --yellow-3: #f6d32d;
    --yellow-4: #f5c211;
    --yellow-5: #e5a50a;
    --orange-1: #ffbe6f;
    --orange-2: #ffa348;
    --orange-3: #ff7800;
    --orange-4: #e66100;
    --orange-5: #c64600;
    --red-1: #f66151;
    --red-2: #ed333b;
    --red-3: #e01b24;
    --red-4: #c01c28;
    --red-5: #a51d2d;
    --purple-1: #dc8add;
    --purple-2: #c061cb;
    --purple-3: #9141ac;
    --purple-4: #813d9c;
    --purple-5: #613583;
    --brown-1: #cdab8f;
    --brown-2: #b5835a;
    --brown-3: #986a44;
    --brown-4: #865e3c;
    --brown-5: #63452c;
    --light-1: #ffffff;
    --light-2: #f6f5f4;
    --light-3: #deddda;
    --light-4: #c0bfbc;
    --light-5: #9a9996;
    --dark-1: #77767b;
    --dark-2: #5e5c64;
    --dark-3: #3d3846;
    --dark-4: #241f31;
    --dark-5: #000000;
}

/* --- Accent color support --- */
:root {
    --accent-blue: #3584e4;
    --accent-teal: #2190a4;
    --accent-green: #3a944a;
    --accent-yellow: #c88800;
    --accent-orange: #ed5b00;
    --accent-red: #e62d42;
    --accent-pink: #d56199;
    --accent-purple: #9141ac;
    --accent-slate: #6f8396;

    --borders: color-mix(in srgb, currentColor 15%, transparent);
}

.accent-blue {
    --accent-bg-color: var(--accent-blue);
    --accent-fg-color: white
}
.accent-teal {
    --accent-bg-color: var(--accent-teal);
    --accent-fg-color: white
}
.accent-green {
    --accent-bg-color: var(--accent-green);
    --accent-fg-color: white
}
.accent-yellow {
    --accent-bg-color: var(--accent-yellow);
    --accent-fg-color: white
}
.accent-orange {
    --accent-bg-color: var(--accent-orange);
    --accent-fg-color: white
}
.accent-red {
    --accent-bg-color: var(--accent-red);
    --accent-fg-color: white
}
.accent-pink {
    --accent-bg-color: var(--accent-pink);
    --accent-fg-color: white
}
.accent-purple {
    --accent-bg-color: var(--accent-purple);
    --accent-fg-color: white
}
.accent-slate {
    --accent-bg-color: var(--accent-slate);
    --accent-fg-color: white
}

/* --- Adwaita default var --- */
:root {
    --destructive-bg-color: var(--red-3);
    --destructive-fg-color: white;
    --success-bg-color: var(--green-4);
    --success-fg-color: white;
    --warning-bg-color: var(--yellow-5);
    --warning-fg-color: rgb(0 0 0 / 80%);
    --error-bg-color: var(--red-3);
    --error-fg-color: white;

    --accent-color: oklab(from var(--accent-bg-color) min(l, 0.5) a b);
    --destructive-color: oklab(
            from var(--destructive-bg-color) min(l, 0.5) a b
    );
    --success-color: oklab(from var(--success-bg-color) min(l, 0.5) a b);
    --warning-color: oklab(from var(--warning-bg-color) min(l, 0.5) a b);
    --error-color: oklab(from var(--error-bg-color) min(l, 0.5) a b);

    --window-bg-color: #fafafb;
    --window-fg-color: rgb(0 0 6 / 80%);
    --view-bg-color: #ffffff;
    --view-fg-color: rgb(0 0 6 / 80%);
    --headerbar-bg-color: #ffffff;
    --headerbar-fg-color: rgb(0 0 6 / 80%);
    --headerbar-border-color: rgb(0 0 6 / 80%);
    --headerbar-backdrop-color: var(--window-bg-color);
    --headerbar-shade-color: rgb(0 0 6 / 12%);
    --headerbar-darker-shade-color: rgb(0 0 6 / 12%);
    --sidebar-bg-color: #ebebed;
    --sidebar-fg-color: rgb(0 0 6 / 80%);
    --sidebar-backdrop-color: #f2f2f4;
    --sidebar-shade-color: rgb(0 0 6 / 7%);
    --sidebar-border-color: rgb(0 0 6 / 7%);
    --secondary-sidebar-bg-color: #f3f3f5;
    --secondary-sidebar-fg-color: rgb(0 0 6 / 80%);
    --secondary-sidebar-backdrop-color: #f6f6fa;
    --secondary-sidebar-shade-color: rgb(0 0 6 / 7%);
    --secondary-sidebar-border-color: rgb(0 0 6 / 7%);
    --card-bg-color: #ffffff;
    --card-fg-color: rgb(0 0 6 / 80%);
    --card-shade-color: rgb(0 0 6 / 7%);
    --dialog-bg-color: #fafafb;
    --dialog-fg-color: rgb(0 0 6 / 80%);
    --popover-bg-color: #ffffff;
    --popover-fg-color: rgb(0 0 6 / 80%);
    --popover-shade-color: rgb(0 0 6 / 7%);
    --thumbnail-bg-color: #ffffff;
    --thumbnail-fg-color: rgb(0 0 6 / 80%);
    --shade-color: rgb(0 0 6 / 7%);
    --scrollbar-outline-color: white;
}

.dark {
    --destructive-bg-color: var(--red-4);
    --success-bg-color: var(--green-5);
    --warning-bg-color: var(--yellow-5);
    --error-bg-color: var(--red-4);

    --accent-color: oklab(from var(--accent-bg-color) min(l, 0.5) a b);
    --destructive-color: oklab(
            from var(--destructive-bg-color) min(l, 0.5) a b
    );
    --success-color: oklab(from var(--success-bg-color) min(l, 0.5) a b);
    --warning-color: oklab(from var(--warning-bg-color) min(l, 0.5) a b);
    --error-color: oklab(from var(--error-bg-color) min(l, 0.5) a b);

    --accent-color: oklab(from var(--accent-bg-color) max(l, 0.85) a b);
    --destructive-color: oklab(
            from var(--destructive-bg-color) max(l, 0.85) a b
    );
    --success-color: oklab(from var(--success-bg-color) max(l, 0.85) a b);
    --warning-color: oklab(from var(--warning-bg-color) max(l, 0.85) a b);
    --error-color: oklab(from var(--error-bg-color) max(l, 0.85) a b);

    --window-bg-color: #222226;
    --window-fg-color: white;
    --view-bg-color: #1d1d20;
    --view-fg-color: white;
    --headerbar-bg-color: #2e2e32;
    --headerbar-fg-color: white;
    --headerbar-border-color: white;
    --headerbar-shade-color: rgb(0 0 6 / 36%);
    --headerbar-darker-shade-color: rgb(0 0 12 / 90%);
    --sidebar-bg-color: #2e2e32;
    --sidebar-fg-color: white;
    --sidebar-backdrop-color: #28282c;
    --sidebar-shade-color: rgb(0 0 6 / 25%);
    --sidebar-border-color: rgb(0 0 6 / 36%);
    --secondary-sidebar-bg-color: #28282c;
    --secondary-sidebar-fg-color: white;
    --secondary-sidebar-backdrop-color: #252529;
    --secondary-sidebar-shade-color: rgb(0 0 6 / 25%);
    --secondary-sidebar-border-color: rgb(0 0 6 / 36%);
    --card-bg-color: rgb(255 255 255 / 8%);
    --card-fg-color: white;
    --card-shade-color: rgb(0 0 6 / 36%);
    --dialog-bg-color: #36363a;
    --dialog-fg-color: white;
    --popover-bg-color: #36363a;
    --popover-fg-color: white;
    --popover-shade-color: rgb(0 0 6 / 25%);
    --thumbnail-bg-color: #39393d;
    --thumbnail-fg-color: white;
    --shade-color: rgb(0 0 6 / 25%);
    --scrollbar-outline-color: rgb(0 0 12 / 95%);
}

/* --- Walker --- */

* {
    all: unset;
}

.normal-icons {
    -gtk-icon-size: 16px;
}

.large-icons {
    -gtk-icon-size: 32px;
}

scrollbar {
    opacity: 0;
}

.box-wrapper {
    box-shadow:
            0 19px 38px rgba(0, 0, 0, 0.3),
            0 15px 12px rgba(0, 0, 0, 0.22);
    background: var(--window-bg-color);
    padding: 20px;
    border-radius: 20px;
    border: 1px solid var(--borders);
}

.preview-box,
.elephant-hint,
.placeholder {
    color: var(--window-fg-color);
}

.box {
}

.search-container {
    border-radius: 10px;
}

.input placeholder {
    opacity: 0.5;
}

.input {
    caret-color: var(--view-fg-color);
    background: var(--view-bg-color);
    padding: 10px;
    color: var(--view-fg-color);
}

.input:focus,
.input:active {
}

.content-container {
}

.placeholder {
}

.scroll {
}

.list {
    color: var(--window-fg-color);
}

child {
}

.item-box {
    border-radius: 10px;
    padding: 10px;
}

.item-quick-activation {
    background: alpha(var(--accent-bg-color), 0.25);
    border-radius: 5px;
    padding: 10px;
}

child:hover .item-box,
child:selected .item-box {
    background: alpha(var(--accent-bg-color), 0.25);
}

.item-text-box {
}

.item-subtext {
    font-size: 12px;
    opacity: 0.5;
}

.providerlist .item-subtext {
    font-size: unset;
    opacity: 0.75;
}

.item-image-text {
    font-size: 28px;
}

.preview {
    border: 1px solid alpha(var(--accent-bg-color), 0.25);
    padding: 10px;
    border-radius: 10px;
    color: var(--accent-fg-color);
}

.calc .item-text {
    font-size: 24px;
}

.calc .item-subtext {
}

.symbols .item-image {
    font-size: 24px;
}

.todo.done .item-text-box {
    opacity: 0.25;
}

.todo.urgent {
    font-size: 24px;
}

.todo.active {
    font-weight: bold;
}

.bluetooth.disconnected {
    opacity: 0.5;
}

.preview .large-icons {
    -gtk-icon-size: 64px;
}

.keybinds-wrapper {
    border-top: 1px solid var(--borders);
    font-size: 12px;
    opacity: 0.5;
    color: var(--window-fg-color);
}

.keybinds {
}

.keybind {
}

.keybind-bind {
    /* color: lighter(@window_bg_color); */
    font-weight: bold;
    text-transform: lowercase;
}

.keybind-label {
}

.error {
    padding: 10px;
    background: var(--error-bg-color);
    color: var(--error-fg-color);
}

:not(.calc).current {
    font-style: italic;
}
```