### PR TITLE
Replace wrapGAppsHook with wrapGAppsHook3

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -11,7 +11,7 @@
   graphene,
   cairo,
   pango,
-  wrapGAppsHook,
+  wrapGAppsHook3,
   poppler,
 }:
 rustPlatform.buildRustPackage rec {
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
     gobject-introspection
     pkg-config
     protobuf
-    wrapGAppsHook
+    wrapGAppsHook3
   ];
 
   buildInputs = [


### PR DESCRIPTION
``error: 'wrapGAppsHook' has been renamed to/replaced by 'wrapGAppsHook3' ``

I got this error when following my nixpkgs master, I tested this change with ur nixpkgs input and it worked, so I think it's best to change it now before it becomes a problem.