### PR TITLE
feat(files): Improve layout of path file items and allow paths outside of $HOME

### DIFF
--- a/resources/themes/default/item_files.xml
+++ b/resources/themes/default/item_files.xml
@@ -37,6 +37,18 @@
             <property name="ellipsize">1</property>
           </object>
         </child>
+        <child>
+          <object class="GtkLabel" id="ItemSubtext">
+            <style>
+              <class name="item-subtext"></class>
+            </style>
+            <property name="wrap">false</property>
+            <property name="vexpand_set">true</property>
+            <property name="vexpand">true</property>
+            <property name="xalign">0</property>
+            <property name="ellipsize">1</property>
+          </object>
+        </child>
       </object>
     </child>
     <child>


### PR DESCRIPTION
This fixes paths not showing when not in the home folder. It also changes the layout slightly as show below

Before:
<img width="1344" height="843" alt="image" src="https://github.com/user-attachments/assets/6de4c5e3-9e3c-4eea-8b12-8d4451d78d75" />


After:

<img width="1344" height="843" alt="image" src="https://github.com/user-attachments/assets/f2fbea75-bdb0-4aca-b555-313152481bb8" />