### PR TITLE
fix: update elephant to support new protocol

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759675127,
-        "narHash": "sha256-AsYUdOukKNXIu47CpQNJeAccu524sIj9UTuP9Aadycs=",
+        "lastModified": 1762026536,
+        "narHash": "sha256-JX3s/1qBc+dQkCa1heZ2PO1Sd6EwrQsEAXxe3CqyFLs=",
         "owner": "abenz1267",
         "repo": "elephant",
-        "rev": "abfa18c844f1028b0b2beef456fee6d40e98dfad",
+        "rev": "0e3b6a99d2a4c8f548435ea0466202d7c1129353",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Problem

After updating to walker 2.8.2, no applications appear in the launcher.

## Root Cause

Walker 2.8.2 changed to a 2-byte protocol header (commit 82840e9), but elephant was pinned to version abfa18c which only supports the old 1-byte header protocol.

## Solution

Update elephant from abfa18c (Oct 5) to 0e3b6a9 (Nov 1) which includes the protocol change (commit c1ea7a0).
