### PR TITLE
fix(nix): add dependencies required for video previews

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,6 +5,7 @@
   protobuf,
   glib,
   gobject-introspection,
+  gst_all_1,
   gtk4,
   gtk4-layer-shell,
   gdk-pixbuf,
@@ -47,7 +48,12 @@ rustPlatform.buildRustPackage rec {
     cairo
     pango
     poppler
-  ];
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-libav
+  ]);
 
   meta = {
     description = "Wayland-native application runner";


### PR DESCRIPTION
Previously walker would crash when trying to preview video files.

```bash
walker
make sure 'walker --gapplication-service' is running!
connecting to elephant...
waiting for elephant to start...
connected.

(walker:91142): Gdk-WARNING **: 14:48:43.120: vkAcquireNextImageKHR(): A surface has changed in such a way that it is no longer compatible with the swapchain. (VK_ERROR_OUT_OF_DATE_KHR) (-1000001004)

(walker:91142): GStreamer-Play-ERROR **: 14:48:45.416: GstPlay: 'playbin3' element not found, please check your setup
fish: Job 1, 'walker' terminated by signal SIGTRAP (Trace or breakpoint trap)
```