### PR TITLE
Improve accent-color support with and without 'accent-color' in gsettings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ mod ui;
 use gtk4::gio::prelude::{ApplicationCommandLineExt, DataInputStreamExtManual, SettingsExt};
 use gtk4::gio::{self, ApplicationCommandLine, ApplicationHoldGuard};
 use gtk4::glib::Priority;
-use gtk4::glib::object::ObjectExt;
 use gtk4::prelude::EntryExt;
 
 use config::get_config;
@@ -130,11 +129,13 @@ fn init_ui(app: &Application, dmenu: bool, theme: &str) {
         adjust_color_scheme(s);
     });
 
-    if settings.has_property("accent-color", None) {
-        adjust_accent_color(&settings);
-        settings.connect_changed(Some("accent-color"), move |s, _| {
-            adjust_accent_color(s);
-        });
+    if let Some(schema) = settings.settings_schema() {
+        if schema.has_key("accent-color") {
+            adjust_accent_color(&settings);
+            settings.connect_changed(Some("accent-color"), move |s, _| {
+                adjust_accent_color(s);
+            });
+        }
     }
 }
 


### PR DESCRIPTION
Following the fix of the crash reported in issue #608, the management of the `accent-color` setting was no longer working.

After investigation, I learned that the properties do not correspond to the "keys" present in a schema, `org.gnome.desktop.interface` being a schema, the old code checked the properties and not the keys. I therefore retrieved the schema to check that the `accent-color` key was present. If the schema is not retrieved or if the key does not exist, then `adjust_accent_color` is not executed.