### PR TITLE
Use wrapGappsHook4 instead of wrapGappsHook3.

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,7 +12,7 @@
   graphene,
   cairo,
   pango,
-  wrapGAppsHook3,
+  wrapGAppsHook4,
   poppler,
 }:
 rustPlatform.buildRustPackage rec {
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage rec {
     gobject-introspection
     pkg-config
     protobuf
-    wrapGAppsHook3
+    wrapGAppsHook4
   ];
 
   buildInputs = [


### PR DESCRIPTION
Needed to change something to try to fix graphical issues (intel iGPU - opening and closing too fast causes hangs, sometimes typing makes the whole screen glitch out) since it might be a download problem so I found a bug.