### PR TITLE
Convert input to lower case

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -373,7 +373,7 @@ fn setup_input_handling(input: &Entry) -> gdk::glib::SignalHandlerId {
     input.connect_changed(move |input| {
         disable_mouse();
 
-        let text = input.text().to_string();
+        let text = input.text().to_string().to_lowercase();
 
         let cfg = get_config();
 


### PR DESCRIPTION
# Problem

As a user I accidentally input text in upper case and I can't find specific application (in my case telegram and some other applications).

I want to be able to find applications regardless case sensitivity.

<img width="596" height="573" alt="2026-01-11-173634_hyprshot" src="https://github.com/user-attachments/assets/f00e874f-5aea-4cd6-86f5-142aa9ceee7a" />
<img width="591" height="583" alt="2026-01-11-173939_hyprshot" src="https://github.com/user-attachments/assets/3f28cda8-f84c-4a7b-a063-4e5580563458" />


# Solution

Always convert input string to lowercase.
<img width="602" height="571" alt="2026-01-11-173827_hyprshot" src="https://github.com/user-attachments/assets/cfd01234-b1a5-4cdd-90dd-d0d689fa542b" />
<img width="618" height="580" alt="2026-01-11-173958_hyprshot" src="https://github.com/user-attachments/assets/faaad2d2-c3d6-409a-8793-1e46ae0e000e" />
