### PR TITLE
truncate label texts with unknown length (#668)

### DIFF
--- a/src/providers/clipboard.rs
+++ b/src/providers/clipboard.rs
@@ -16,6 +16,8 @@ impl Clipboard {
     }
 }
 
+const LABEL_MAX_LEN: usize = 100;
+
 impl Provider for Clipboard {
     fn get_name(&self) -> &str {
         self.name
@@ -31,7 +33,9 @@ impl Provider for Clipboard {
             return;
         }
 
-        label.set_label(item.text.trim());
+        let text = item.text.trim();
+        let truncated: String = text.chars().take(LABEL_MAX_LEN).collect();
+        label.set_label(truncated.as_str());
     }
 
     fn subtext_transformer(&self, item: &Item, label: &gtk4::Label) {


### PR DESCRIPTION
The GTK docs specify labels to be for "Displaying a small amount of text" and for absurd sizes it completely kills the performance causing the GUI to hang for a long time. Truncate the text data used for previews to avoid abusing the poor labels..

The max length is primarily chosen to limit the data sent to GTK to avoid performance problems, yet allow for some flexibility for different label widths in the GUI.

Fixes: #668