### PR TITLE
fix: restore initial dimensions and placeholder on application restart

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,8 @@ use crate::protos::QueryResponseObject;
 use crate::protos::generated_proto::query::{QueryResponse, query_response};
 use crate::providers::setup_providers;
 use crate::state::{
-    get_last_query, get_parameter_height, get_parameter_max_height, get_parameter_max_width,
+    get_last_query,
+    get_parameter_height, get_parameter_max_height, get_parameter_max_width,
     get_parameter_min_height, get_parameter_min_width, get_parameter_width, get_placeholder,
     get_provider, get_theme, has_elephant, has_theme, is_connected, is_dmenu, is_dmenu_keep_open,
     is_emergency, is_input_only, is_no_hints, is_no_search, is_param_close, is_password_mode,
@@ -712,42 +713,42 @@ fn apply_flag_logic() {
         }
 
         if let Some(val) = get_parameter_height() {
-            set_initial_height(Some(w.box_wrapper.height_request()));
+            set_initial_height(Some(w.default_box_height));
             w.box_wrapper.set_height_request(val);
         }
 
         if let Some(val) = get_parameter_width() {
-            set_initial_width(Some(w.box_wrapper.width_request()));
+            set_initial_width(Some(w.default_box_width));
             w.box_wrapper.set_width_request(val);
         }
 
         if let Some(val) = get_parameter_min_width() {
-            set_initial_min_width(Some(w.scroll.min_content_width()));
+            set_initial_min_width(Some(w.default_scroll_min_width));
             w.scroll.set_min_content_width(val);
         }
 
         if let Some(val) = get_parameter_min_height() {
-            set_initial_min_height(Some(w.scroll.min_content_height()));
+            set_initial_min_height(Some(w.default_scroll_min_height));
             w.scroll.set_min_content_height(val);
         }
 
         if let Some(val) = get_parameter_max_width() {
-            set_initial_max_width(Some(w.scroll.max_content_width()));
+            set_initial_max_width(Some(w.default_scroll_max_width));
             w.scroll.set_max_content_width(val);
         }
 
         if let Some(val) = get_parameter_max_height() {
-            set_initial_max_height(Some(w.scroll.max_content_height()));
+            set_initial_max_height(Some(w.default_scroll_max_height));
             w.scroll.set_max_content_height(val);
         }
 
         if get_parameter_min_width().is_some() || get_parameter_max_width().is_some() {
-            set_initial_width(Some(w.box_wrapper.width_request()));
+            set_initial_width(Some(w.default_box_width));
             w.box_wrapper.set_width_request(-1);
         }
 
         if get_parameter_min_height().is_some() || get_parameter_max_height().is_some() {
-            set_initial_height(Some(w.box_wrapper.height_request()));
+            set_initial_height(Some(w.default_box_height));
             w.box_wrapper.set_height_request(-1);
         }
 

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -112,6 +112,12 @@ pub struct WindowData {
     pub content_container: gtk4::Box,
     pub box_wrapper: gtk4::Box,
     pub error: gtk4::Label,
+    pub default_box_height: i32,
+    pub default_box_width: i32,
+    pub default_scroll_max_height: i32,
+    pub default_scroll_min_height: i32,
+    pub default_scroll_max_width: i32,
+    pub default_scroll_min_width: i32,
 }
 
 pub fn with_window<F, R>(f: F) -> R
@@ -339,7 +345,20 @@ pub fn setup_theme_window(app: &Application, val: &Theme) -> Result<WindowData, 
         keybinds,
         global_keybinds,
         item_keybinds,
+        default_box_height: 0,
+        default_box_width: 0,
+        default_scroll_max_height: 0,
+        default_scroll_min_height: 0,
+        default_scroll_max_width: 0,
+        default_scroll_min_width: 0,
     };
+
+    ui.default_box_height = ui.box_wrapper.height_request();
+    ui.default_box_width = ui.box_wrapper.width_request();
+    ui.default_scroll_max_height = ui.scroll.max_content_height();
+    ui.default_scroll_min_height = ui.scroll.min_content_height();
+    ui.default_scroll_max_width = ui.scroll.max_content_width();
+    ui.default_scroll_min_width = ui.scroll.min_content_width();
 
     if let Some(p) = &ui.preview_container {
         p.set_visible(false);


### PR DESCRIPTION
To be transparent, I got help from Claude Code for this fix, so consider this a suggestion rather than the definitive solution.

Unfortunately, I can't figure it out without it, and I'm still not sure if it's a problem with me (perhaps related to some configuration or GNOME) or a logical one.

I apologize if there are any suboptimal choices. I'll just leave the suggestion, hoping to address this difficulty.

---

When using `walker` as a `--gapplication-service`, closing and immediately reopening with different `--maxheight`/`--minheight` values causes the second invocation to be silently capped to the dimensions of the first.

Capture the true XML defaults once at window creation time and store them in _WindowData_.

This fix seems to work on GNOME 48 (Debian Trixie), but not on GNOME 46 (Ubuntu 24.04).

Closes #703 