### PR TITLE
fix: prevent ghost window and item list wipe

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -887,9 +887,9 @@ pub fn quit(app: &Application, cancelled: bool) {
         return;
     }
 
-    app.active_window().unwrap().set_visible(false);
-
     with_window(|w| {
+        w.window.set_visible(false);
+
         while let Some(preview) = w.builder.object::<Box>("Preview")
             && let Some(child) = preview.first_child()
         {
@@ -933,74 +933,72 @@ pub fn quit(app: &Application, cancelled: bool) {
         set_dmenu_keep_open(false);
     }
 
-    gtk4::glib::idle_add_once(|| {
-        with_window(|w| {
-            if let Some(input) = &w.input {
-                if !is_dmenu() {
-                    set_last_query(provider, input.text().to_string());
-                }
-
-                if !get_initial_placeholder().is_empty() {
-                    set_placeholder_text(&get_initial_placeholder());
-                    set_initial_placeholder(String::new());
-                }
-            };
-
-            if let Some(search_container) = &w.search_container {
-                search_container.set_visible(true);
+    with_window(|w| {
+        if let Some(input) = &w.input {
+            if !is_dmenu() {
+                set_last_query(provider, input.text().to_string());
             }
 
-            w.item_keybinds.set_visible(true);
-            w.keybinds.set_visible(true);
-
-            w.content_container.set_visible(true);
-
-            if let Some(val) = get_initial_height() {
-                w.box_wrapper.set_height_request(val);
-                set_initial_height(None);
+            if !get_initial_placeholder().is_empty() {
+                set_placeholder_text(&get_initial_placeholder());
+                set_initial_placeholder(String::new());
             }
+        };
 
-            if let Some(val) = get_initial_width() {
-                w.box_wrapper.set_width_request(val);
-                set_initial_width(None);
-            }
+        if let Some(search_container) = &w.search_container {
+            search_container.set_visible(true);
+        }
 
-            if let Some(val) = get_initial_max_width() {
-                w.scroll.set_max_content_width(val);
-                set_initial_max_width(None);
-            }
+        w.item_keybinds.set_visible(true);
+        w.keybinds.set_visible(true);
 
-            if let Some(val) = get_initial_min_width() {
-                w.scroll.set_min_content_width(val);
-                set_initial_min_width(None);
-            }
+        w.content_container.set_visible(true);
 
-            if let Some(val) = get_initial_max_height() {
-                w.scroll.set_max_content_height(val);
-                set_initial_max_height(None);
-            }
+        if let Some(val) = get_initial_height() {
+            w.box_wrapper.set_height_request(val);
+            set_initial_height(None);
+        }
 
-            if let Some(val) = get_initial_min_height() {
-                w.scroll.set_min_content_height(val);
-                set_initial_min_height(None);
-            }
+        if let Some(val) = get_initial_width() {
+            w.box_wrapper.set_width_request(val);
+            set_initial_width(None);
+        }
 
-            w.items.remove_all();
-            w.list.set_max_columns(w.list_max_columns);
-            w.list.set_min_columns(w.list_max_columns);
+        if let Some(val) = get_initial_max_width() {
+            w.scroll.set_max_content_width(val);
+            set_initial_max_width(None);
+        }
 
-            let is_grid = w.list_max_columns > 1;
+        if let Some(val) = get_initial_min_width() {
+            w.scroll.set_min_content_width(val);
+            set_initial_min_width(None);
+        }
 
-            set_is_grid(is_grid);
+        if let Some(val) = get_initial_max_height() {
+            w.scroll.set_max_content_height(val);
+            set_initial_max_height(None);
+        }
 
-            if is_grid {
-                w.list.add_css_class("grid");
-            } else {
-                w.list.remove_css_class("grid");
-            }
+        if let Some(val) = get_initial_min_height() {
+            w.scroll.set_min_content_height(val);
+            set_initial_min_height(None);
+        }
 
-            set_theme(get_config().theme.clone());
-        });
+        w.items.remove_all();
+        w.list.set_max_columns(w.list_max_columns);
+        w.list.set_min_columns(w.list_max_columns);
+
+        let is_grid = w.list_max_columns > 1;
+
+        set_is_grid(is_grid);
+
+        if is_grid {
+            w.list.add_css_class("grid");
+        } else {
+            w.list.remove_css_class("grid");
+        }
+
+        set_theme(get_config().theme.clone());
     });
 }
 


### PR DESCRIPTION
To be transparent, I got help from Claude Code for this fix, so consider this a suggestion rather than the definitive solution.

I repeatedly ran into an issue where a `walker` window would hang after closing on GNOME (both 46 and 48). Even refocusing it and trying to close it again didn’t work. The only way to recover was to `pkill -f walker` and restart it.

Since I wasn’t sure where the problem originated and I don’t know Rust, I started investigating to identify the bottleneck. This is what I came up with:

--- 

Two related bugs affecting `walker` running as a `--gapplication-service` on compositors without native **wlr-layer-shell** support (e.g. GNOME):

## Bug 1: Ghost window that cannot be closed.

On GNOME, _active_window()_ returns the window that the compositor considers focused. If `walker` momentarily loses focus (compositor animations, click outside, etc.), `active_window()` returns `None`. The window remains visible and stuck, unresponsive to further close attempts.

## Bug 2: Item list wiped on rapid reopen.

The `idle_add_once` callback in `quit()` unconditionally called `w.items.remove_all()`. If a new invocation of `walker` arrived and populated the list between `quit()` scheduling the idle and its execution, the callback would wipe the freshly loaded items, leaving an empty window.