### PR TITLE
fix: blur region out of sync when window resizes

### DIFF
--- a/src/wayland_blur.rs
+++ b/src/wayland_blur.rs
@@ -3,7 +3,6 @@ use std::rc::Rc;
 
 use gdk4_wayland::prelude::WaylandSurfaceExtManual;
 use gdk4_wayland::{WaylandDisplay, WaylandSurface};
-use gtk4::glib::ControlFlow;
 use gtk4::prelude::*;
 use gtk4::{Box as GtkBox, Window};
 use wayland_client::protocol::wl_compositor::WlCompositor;
@@ -97,9 +96,31 @@ pub fn attach_blur(window: &Window, target: &GtkBox) {
 
     {
         let ctx = ctx.clone();
-        window.connect_realize(move |window| match init_context(window) {
-            Ok(c) => *ctx.borrow_mut() = Some(c),
-            Err(e) => eprintln!("background-effect-v1 unavailable: {e}"),
+        let target = target.clone();
+        window.connect_realize(move |window| {
+            let Ok(c) = init_context(window) else {
+                eprintln!("background-effect-v1 unavailable");
+                return;
+            };
+            *ctx.borrow_mut() = Some(c);
+
+            if let Some(fc) = window.frame_clock() {
+                let ctx = ctx.clone();
+                let target = target.clone();
+                let window = window.clone();
+                fc.connect_layout(move |_| {
+                    if let Some(c) = ctx.borrow_mut().as_mut()
+                        && let Some(bounds) = target.compute_bounds(&window)
+                    {
+                        c.update_region((
+                            bounds.x() as i32,
+                            bounds.y() as i32,
+                            bounds.width() as i32,
+                            bounds.height() as i32,
+                        ));
+                    }
+                });
+            }
         });
     }
 
@@ -107,24 +128,6 @@ pub fn attach_blur(window: &Window, target: &GtkBox) {
         let ctx = ctx.clone();
         window.connect_unrealize(move |_| {
             ctx.borrow_mut().take();
-        });
-    }
-
-    {
-        let ctx = ctx.clone();
-        let window = window.clone();
-        target.add_tick_callback(move |target, _| {
-            if let Some(c) = ctx.borrow_mut().as_mut() {
-                if let Some(bounds) = target.compute_bounds(&window) {
-                    c.update_region((
-                        bounds.x() as i32,
-                        bounds.y() as i32,
-                        bounds.width() as i32,
-                        bounds.height() as i32,
-                    ));
-                }
-            }
-            ControlFlow::Continue
         });
     }
 }


### PR DESCRIPTION
Blur region stays at the old window size after a resize, and updates only on the next phase (i.e. next resize).
You can test this by running this for example (this is the same command I tested with): `cargo run --release -- -m wireplumber --minwidth 644 --maxwidth 644 --minheight 300 --maxheight 300`

## The Issue

`add_tick_callback` fires during [GTK's UPDATE phase](https://docs.gtk.org/gdk4/signal.FrameClock.update.html), so `compute_bounds()` returned stale bounds and the blur region lagged one frame behind.

## The Solution

Use [`frame_clock.connect_layout()`](https://docs.gtk.org/gdk4/signal.FrameClock.layout.html) instead.
Quoting from their docs: "Any work to update sizes and positions of application elements should be performed. GTK normally handles this internally."

Before
https://github.com/user-attachments/assets/ae9b9269-b565-45c4-a5d3-bd34e3301dab

After
https://github.com/user-attachments/assets/7467bae2-53cb-4ef6-9ea7-59b5b2938aa9