### PR TITLE
fix(config): correct bitwarden TOTP action names

### DIFF
--- a/resources/config.toml
+++ b/resources/config.toml
@@ -196,8 +196,8 @@ bitwarden = [
   { action = "typepassword", label = "type password", default = true, bind = "ctrl p" },
   { action = "copyusername", label = "copy username", bind = "shift Return" },
   { action = "typeusername", label = "type username", bind = "ctrl u" },
-  { action = "copyotp", label = "copy 2fa", bind = "ctrl Return" },
-  { action = "typeotp", label = "type 2fa", bind = "ctrl t" },
+  { action = "copytotp", label = "copy 2fa", bind = "ctrl Return" },
+  { action = "typetotp", label = "type 2fa", bind = "ctrl t" },
   { action = "syncvault", label = "sync", bind = "ctrl s" },
 ]
 


### PR DESCRIPTION
## Summary

The default keybinds for the `bitwarden` provider in `resources/config.toml` reference action names `copyotp` and `typeotp`, but the elephant bitwarden provider exports them as `copytotp` and `typetotp`.

See [`abenz1267/elephant/internal/providers/bitwarden/activate.go`](https://github.com/abenz1267/elephant/blob/master/internal/providers/bitwarden/activate.go):

```go
ActionCopyTotp = "copytotp"
ActionTypeTotp = "typetotp"
```

Because of the mismatch, the default `ctrl Return` (copy 2FA) and `ctrl t` (type 2FA) keybinds silently no-op — walker dispatches actions that elephant doesn't recognize.

## Change

```diff
-  { action = "copyotp", label = "copy 2fa", bind = "ctrl Return" },
-  { action = "typeotp", label = "type 2fa", bind = "ctrl t" },
+  { action = "copytotp", label = "copy 2fa", bind = "ctrl Return" },
+  { action = "typetotp", label = "type 2fa", bind = "ctrl t" },
```

## Test plan

- [x] Verified action constant names in upstream elephant source
- [x] Verified locally that overriding `[providers.actions].bitwarden` with the corrected names makes `ctrl Return` copy the TOTP code as expected