### PR TITLE
multi-select: shift+arrows, space, ctrl+click to mark rows

### DIFF
--- a/resources/config.toml
+++ b/resources/config.toml
@@ -48,6 +48,9 @@ quick_activate = ["F1", "F2", "F3", "F4"]
 page_down = ["Page_Down"]
 page_up = ["Page_Up"]
 show_actions = ["alt j"]
+select_toggle_current = ["space"]
+select_extend_up = ["shift Up"]
+select_extend_down = ["shift Down"]
 
 [providers]
 default = [

--- a/resources/themes/default/style.css
+++ b/resources/themes/default/style.css
@@ -102,6 +102,22 @@ row:selected .item-box {
   background: alpha(@accent_bg_color, 0.25);
 }
 
+/* Multi-row selection: distinct from the single-row highlight cursor.
+   A row is added to this set via Space / shift+Arrow / ctrl+click; the
+   class is applied directly to the .item-box widget from Rust. The left
+   border + slightly stronger tint make multi-selected rows visually
+   distinct from both unselected rows and the highlight cursor. */
+.item-box.selected-multi {
+  background: alpha(@accent_bg_color, 0.35);
+  border-left: 3px solid @accent_bg_color;
+  padding-left: 7px;
+}
+
+child:selected .item-box.selected-multi,
+row:selected .item-box.selected-multi {
+  background: alpha(@accent_bg_color, 0.5);
+}
+
 .item-text-box {
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -162,6 +162,12 @@ struct PartialKeybinds {
     pub page_down: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page_up: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub select_toggle_current: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub select_extend_up: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub select_extend_down: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -429,6 +435,15 @@ impl Keybinds {
         if let Some(v) = partial.page_up {
             self.page_up = v;
         }
+        if let Some(v) = partial.select_toggle_current {
+            self.select_toggle_current = v;
+        }
+        if let Some(v) = partial.select_extend_up {
+            self.select_extend_up = v;
+        }
+        if let Some(v) = partial.select_extend_down {
+            self.select_extend_down = v;
+        }
     }
 }
 
@@ -501,6 +516,9 @@ pub struct Keybinds {
     pub quick_activate: Option<Vec<String>>,
     pub page_down: Vec<String>,
     pub page_up: Vec<String>,
+    pub select_toggle_current: Vec<String>,
+    pub select_extend_up: Vec<String>,
+    pub select_extend_down: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/data.rs
+++ b/src/data.rs
@@ -9,13 +9,14 @@ use crate::providers::PROVIDERS;
 use crate::state::{
     get_action_menu_query, get_async_after, get_current_prefix, get_current_set, get_error,
     get_prefix_provider, get_provider, is_actions_menu, is_connected, is_connecting, is_dmenu,
-    is_emergency, is_index, is_service, set_async_after, set_current_prefix, set_error,
-    set_global_provider_actions, set_global_provider_state, set_is_connected, set_is_connecting,
-    set_is_emergency, set_is_visible, set_prefix_provider, set_provider, set_query,
+    is_emergency, is_index, is_service, multi_selected_clear, set_async_after, set_current_prefix,
+    set_error, set_global_provider_actions, set_global_provider_state, set_is_connected,
+    set_is_connecting, set_is_emergency, set_is_visible, set_prefix_provider, set_provider,
+    set_query,
 };
 use crate::ui::window::{
-    check_error, handle_changed_items, reset_actions_menu, set_input_text, set_keybind_hint,
-    with_window,
+    check_error, handle_changed_items, refresh_multi_select_styling, reset_actions_menu,
+    set_input_text, set_keybind_hint, with_window,
 };
 use crate::{QueryResponseObject, send_message};
 use gtk4::glib::Object;
@@ -38,6 +39,12 @@ static BLUETOOTHCONN: Mutex<Option<UnixStream>> = Mutex::new(None);
 
 pub fn input_changed(text: &str) {
     set_current_prefix(String::new());
+
+    // Query changes always rebuild the result list, so any indices held in
+    // the multi-select set would be stale. Reset them and repaint visible
+    // rows to drop the highlight CSS class.
+    multi_selected_clear();
+    refresh_multi_select_styling();
 
     with_window(|w| {
         let is_empty = if text.is_empty() {

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -19,6 +19,9 @@ pub const ACTION_QUICK_ACTIVATE: &str = "%QUICK_ACTIVATE%";
 pub const ACTION_SELECT_PAGE_DOWN: &str = "%PAGE_DOWN%";
 pub const ACTION_SELECT_PAGE_UP: &str = "%PAGE_UP%";
 pub const ACTION_SHOW_ACTIONS: &str = "%SHOW_ACTIONS%";
+pub const ACTION_SELECT_TOGGLE_CURRENT: &str = "%SELECT_TOGGLE_CURRENT%";
+pub const ACTION_SELECT_EXTEND_UP: &str = "%SELECT_EXTEND_UP%";
+pub const ACTION_SELECT_EXTEND_DOWN: &str = "%SELECT_EXTEND_DOWN%";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub enum AfterAction {
@@ -341,6 +344,51 @@ pub fn setup_binds() {
                 default: None,
                 bind: Some(b.clone()),
                 label: Some("select page up".to_string()),
+                after: Some(AfterAction::Nothing),
+            },
+            "",
+        )
+        .unwrap();
+    });
+
+    config.keybinds.select_toggle_current.iter().for_each(|b| {
+        parse_bind(
+            &Action {
+                action: ACTION_SELECT_TOGGLE_CURRENT.to_string(),
+                unset: None,
+                default: None,
+                bind: Some(b.clone()),
+                label: Some("toggle multi-select".to_string()),
+                after: Some(AfterAction::Nothing),
+            },
+            "",
+        )
+        .unwrap();
+    });
+
+    config.keybinds.select_extend_up.iter().for_each(|b| {
+        parse_bind(
+            &Action {
+                action: ACTION_SELECT_EXTEND_UP.to_string(),
+                unset: None,
+                default: None,
+                bind: Some(b.clone()),
+                label: Some("extend multi-select up".to_string()),
+                after: Some(AfterAction::Nothing),
+            },
+            "",
+        )
+        .unwrap();
+    });
+
+    config.keybinds.select_extend_down.iter().for_each(|b| {
+        parse_bind(
+            &Action {
+                action: ACTION_SELECT_EXTEND_DOWN.to_string(),
+                unset: None,
+                default: None,
+                bind: Some(b.clone()),
+                label: Some("extend multi-select down".to_string()),
                 after: Some(AfterAction::Nothing),
             },
             "",

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::{OnceLock, RwLock};
 
 use crate::data::get_provider_state;
@@ -62,6 +62,7 @@ pub struct AppState {
     current_set: String,
     is_visible: bool,
     query: String,
+    multi_selected: BTreeSet<u32>,
 }
 
 pub fn init_app_state() {
@@ -554,4 +555,53 @@ pub fn set_global_provider_state(state: ProviderStateResponse) {
     } else {
         clear_global_keybind_hints();
     }
+}
+
+// ---- Multi-row selection state ---------------------------------------------
+//
+// `multi_selected` tracks the *additional* set of selected rows by index,
+// parallel to the single-row highlight cursor maintained by SingleSelection.
+// When non-empty, activating the default action operates on each selected
+// row in ascending order. The set is cleared whenever the query changes
+// (see data::input_changed) and after a multi-activation pass.
+
+pub fn multi_selected_contains(idx: u32) -> bool {
+    STATE
+        .get()
+        .unwrap()
+        .read()
+        .unwrap()
+        .multi_selected
+        .contains(&idx)
+}
+
+pub fn multi_selected_toggle(idx: u32) -> bool {
+    let mut s = STATE.get().unwrap().write().unwrap();
+    if s.multi_selected.contains(&idx) {
+        s.multi_selected.remove(&idx);
+        false
+    } else {
+        s.multi_selected.insert(idx);
+        true
+    }
+}
+
+pub fn multi_selected_snapshot() -> Vec<u32> {
+    STATE
+        .get()
+        .unwrap()
+        .read()
+        .unwrap()
+        .multi_selected
+        .iter()
+        .copied()
+        .collect()
+}
+
+pub fn multi_selected_is_empty() -> bool {
+    STATE.get().unwrap().read().unwrap().multi_selected.is_empty()
+}
+
+pub fn multi_selected_clear() {
+    STATE.get().unwrap().write().unwrap().multi_selected.clear();
 }

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -4,8 +4,9 @@ use crate::{
     data::{activate, input_changed, set_state},
     keybinds::{
         ACTION_CLOSE, ACTION_QUICK_ACTIVATE, ACTION_RESUME_LAST_QUERY, ACTION_SELECT_DOWN,
-        ACTION_SELECT_LEFT, ACTION_SELECT_NEXT, ACTION_SELECT_PAGE_DOWN, ACTION_SELECT_PAGE_UP,
-        ACTION_SELECT_PREVIOUS, ACTION_SELECT_RIGHT, ACTION_SELECT_UP, ACTION_SHOW_ACTIONS,
+        ACTION_SELECT_EXTEND_DOWN, ACTION_SELECT_EXTEND_UP, ACTION_SELECT_LEFT, ACTION_SELECT_NEXT,
+        ACTION_SELECT_PAGE_DOWN, ACTION_SELECT_PAGE_UP, ACTION_SELECT_PREVIOUS,
+        ACTION_SELECT_RIGHT, ACTION_SELECT_TOGGLE_CURRENT, ACTION_SELECT_UP, ACTION_SHOW_ACTIONS,
         ACTION_TOGGLE_EXACT, Action, AfterAction, format_bind_symbols, get_bind,
         get_fallback_action, get_provider_bind, get_provider_global_bind, get_show_actions_action,
     },
@@ -23,17 +24,18 @@ use crate::{
         get_initial_placeholder, get_initial_width, get_last_query, get_placeholder,
         get_prefix_provider, get_provider, get_query, get_theme, is_actions_menu, is_connected,
         is_dmenu, is_dmenu_exit_after, is_dmenu_keep_open, is_emergency, is_grid, is_no_hints,
-        is_select_single, is_service, set_action_menu_item, set_action_menu_prefix,
-        set_action_menu_query, set_async_after, set_current_prefix, set_current_set,
-        set_dmenu_current, set_dmenu_exit_after, set_dmenu_keep_open, set_error, set_hide_qa,
-        set_index, set_initial_height, set_initial_max_height, set_initial_max_width,
-        set_initial_min_height, set_initial_min_width, set_initial_placeholder, set_initial_width,
-        set_input_only, set_is_actions_menu, set_is_dmenu, set_is_grid,
-        set_is_stay_open_explicit_provider, set_is_visible, set_last_query, set_no_hints,
-        set_no_search, set_param_close, set_parameter_height, set_parameter_max_height,
-        set_parameter_max_width, set_parameter_min_height, set_parameter_min_width,
-        set_parameter_width, set_password_mode, set_placeholder, set_provider, set_query,
-        set_theme,
+        is_select_single, is_service, multi_selected_clear, multi_selected_contains,
+        multi_selected_is_empty, multi_selected_snapshot, multi_selected_toggle,
+        set_action_menu_item, set_action_menu_prefix, set_action_menu_query, set_async_after,
+        set_current_prefix, set_current_set, set_dmenu_current, set_dmenu_exit_after,
+        set_dmenu_keep_open, set_error, set_hide_qa, set_index, set_initial_height,
+        set_initial_max_height, set_initial_max_width, set_initial_min_height,
+        set_initial_min_width, set_initial_placeholder, set_initial_width, set_input_only,
+        set_is_actions_menu, set_is_dmenu, set_is_grid, set_is_stay_open_explicit_provider,
+        set_is_visible, set_last_query, set_no_hints, set_no_search, set_param_close,
+        set_parameter_height, set_parameter_max_height, set_parameter_max_width,
+        set_parameter_min_height, set_parameter_min_width, set_parameter_width, set_password_mode,
+        set_placeholder, set_provider, set_query, set_theme,
     },
     theme::{Theme, setup_layer_shell, with_themes},
 };
@@ -74,6 +76,48 @@ use std::{
 thread_local! {
     pub static WINDOWS: OnceCell<HashMap<String, WindowData>> = const { OnceCell::new() };
     pub static CSS_PROVIDER: RefCell<Option<CssProvider>> = const { RefCell::new(None) };
+    // Registry of currently-bound (position, itembox) rows. Maintained by the
+    // factory's connect_bind / connect_unbind. Used to repaint the
+    // `selected-multi` CSS class when the multi-select set changes without
+    // forcing a full rebind / scroll churn.
+    pub static BOUND_ROWS: RefCell<HashMap<u32, gtk4::Box>> = RefCell::new(HashMap::new());
+}
+
+/// CSS class added to a row widget while its index is in the multi-select set.
+pub const MULTI_SELECT_CSS_CLASS: &str = "selected-multi";
+
+/// Register a row widget under its current position so multi-select repaints
+/// can find it later.
+pub fn register_bound_row(pos: u32, itembox: &gtk4::Box) {
+    BOUND_ROWS.with(|r| {
+        r.borrow_mut().insert(pos, itembox.clone());
+    });
+    if multi_selected_contains(pos) {
+        itembox.add_css_class(MULTI_SELECT_CSS_CLASS);
+    } else {
+        itembox.remove_css_class(MULTI_SELECT_CSS_CLASS);
+    }
+}
+
+/// Drop a row widget from the registry (called from connect_unbind).
+pub fn unregister_bound_row(pos: u32) {
+    BOUND_ROWS.with(|r| {
+        r.borrow_mut().remove(&pos);
+    });
+}
+
+/// Refresh `selected-multi` on every currently-bound row to match the current
+/// `multi_selected` set. Cheap: only iterates visible rows.
+pub fn refresh_multi_select_styling() {
+    BOUND_ROWS.with(|r| {
+        for (pos, itembox) in r.borrow().iter() {
+            if multi_selected_contains(*pos) {
+                itembox.add_css_class(MULTI_SELECT_CSS_CLASS);
+            } else {
+                itembox.remove_css_class(MULTI_SELECT_CSS_CLASS);
+            }
+        }
+    });
 }
 
 pub fn set_css_provider(provider: CssProvider) {
@@ -449,6 +493,23 @@ fn setup_window_behavior(ui: &WindowData, app: &Application) {
 }
 
 fn activate_default(app: &Application) {
+    // Snapshot the multi-select set before touching the window. If any rows
+    // are checked off, iterate them in ascending order and fire each row's
+    // default action. The launcher is kept open across the iteration if any
+    // action requests KeepOpen — see below.
+    let multi = multi_selected_snapshot();
+
+    if multi.is_empty() {
+        // Fast-path / fully backwards-compatible single-row behaviour.
+        activate_single_selected(app);
+        return;
+    }
+
+    activate_multi_selected(app, &multi);
+}
+
+/// Original single-row activate path (the one before multi-select existed).
+fn activate_single_selected(app: &Application) {
     with_window(|w| {
         let query = w.input.as_ref().map(Entry::text).unwrap_or_default();
 
@@ -475,6 +536,149 @@ fn activate_default(app: &Application) {
             handle_after(&after, app, query.to_string());
         }
     });
+}
+
+/// Iterate the multi-selected indices (already ascending — BTreeSet) and fire
+/// the default action for each row. If any action wants `KeepOpen`, that's
+/// what we honor at the end — otherwise we use the last action's after value.
+/// A small delay between activates avoids overwhelming elephant.
+fn activate_multi_selected(app: &Application, indices: &[u32]) {
+    use std::{thread::sleep, time::Duration};
+
+    // Resolve every (response, provider, action) tuple up front so we don't
+    // re-enter `with_window` (and risk RefCell trouble) inside the loop.
+    let resolved: Vec<(QueryResponse, String, Action, String)> = with_window(|w| {
+        let query: String = w
+            .input
+            .as_ref()
+            .map(|e| e.text().to_string())
+            .unwrap_or_default();
+        let providers = PROVIDERS.get().unwrap();
+
+        indices
+            .iter()
+            .filter_map(|&idx| {
+                let obj = w
+                    .selection
+                    .item(idx)
+                    .map(Object::downcast::<QueryResponseObject>)
+                    .and_then(Result::ok)?;
+                let response = obj.response();
+                let item = response.item.as_ref()?.clone();
+                let provider = item.provider.clone();
+                let p = providers.get(&provider)?;
+                let actions = p.get_keybind_hint(&item.actions);
+                let action = if item.actions.len() == 1 {
+                    actions
+                        .iter()
+                        .find(|a| a.action == *item.actions.first().unwrap())
+                        .cloned()?
+                } else {
+                    actions
+                        .iter()
+                        .find(|a| a.default.unwrap_or(false))
+                        .cloned()?
+                };
+                Some((response, provider, action, query.clone()))
+            })
+            .collect()
+    });
+
+    if resolved.is_empty() {
+        multi_selected_clear();
+        return;
+    }
+
+    let mut keep_open = false;
+    let mut last_after = AfterAction::Close;
+    let last_idx = resolved.len() - 1;
+
+    for (i, (response, provider, action, query)) in resolved.into_iter().enumerate() {
+        activate(Some(response), &provider, &query, &action);
+
+        let after = action.after.as_ref().unwrap_or(&AfterAction::Close).clone();
+        if matches!(after, AfterAction::KeepOpen) {
+            keep_open = true;
+        }
+        if i == last_idx {
+            last_after = after;
+        }
+
+        // Small breather so elephant doesn't choke on rapid-fire Activates
+        // from the same client. Skip on the final iteration.
+        if i != last_idx {
+            sleep(Duration::from_millis(50));
+        }
+    }
+
+    // Clear selection state before handling `after`, because some after
+    // variants close the window (which already clears state) and we want a
+    // consistent post-condition either way.
+    multi_selected_clear();
+    refresh_multi_select_styling();
+
+    let final_after = if keep_open {
+        AfterAction::KeepOpen
+    } else {
+        last_after
+    };
+
+    let query = with_window(|w| {
+        w.input
+            .as_ref()
+            .map(|e| e.text().to_string())
+            .unwrap_or_default()
+    });
+    handle_after(&final_after, app, query);
+}
+
+/// Toggle multi-selection of the currently-highlighted row.
+pub fn select_toggle_current() {
+    with_window(|w| {
+        let n = w.selection.n_items();
+        if n == 0 {
+            return;
+        }
+        let cur = w.selection.selected();
+        if cur >= n {
+            return;
+        }
+        multi_selected_toggle(cur);
+    });
+    refresh_multi_select_styling();
+}
+
+/// Move the highlight up by one and toggle the row stepped onto.
+pub fn select_extend_up() {
+    // `select_previous` honors selection_wrap; we follow it for parity.
+    select_previous();
+    with_window(|w| {
+        let n = w.selection.n_items();
+        if n == 0 {
+            return;
+        }
+        let cur = w.selection.selected();
+        if cur < n {
+            multi_selected_toggle(cur);
+        }
+    });
+    refresh_multi_select_styling();
+}
+
+/// Move the highlight down by one and toggle the row stepped onto.
+pub fn select_extend_down() {
+    select_next();
+    with_window(|w| {
+        let n = w.selection.n_items();
+        if n == 0 {
+            return;
+        }
+        let cur = w.selection.selected();
+        if cur < n {
+            multi_selected_toggle(cur);
+        }
+    });
+    refresh_multi_select_styling();
 }
 
 fn setup_input_handling(input: &Entry) -> gdk::glib::SignalHandlerId {
@@ -714,6 +918,9 @@ fn setup_keyboard_handling(ui: &WindowData) {
                         ACTION_SELECT_PAGE_DOWN => select_page_down(),
                         ACTION_SELECT_PAGE_UP => select_page_up(),
                         ACTION_SHOW_ACTIONS => show_actions_menu(get_selected_query_response()),
+                        ACTION_SELECT_TOGGLE_CURRENT => select_toggle_current(),
+                        ACTION_SELECT_EXTEND_UP => select_extend_up(),
+                        ACTION_SELECT_EXTEND_DOWN => select_extend_down(),
                         action if action.starts_with(ACTION_QUICK_ACTIVATE) => {
                             if let Some((_, after)) = action.split_once(":") {
                                 let i: u32 = after.parse().unwrap();
@@ -796,6 +1003,7 @@ fn setup_list_behavior(ui: &WindowData) {
             .downcast_ref::<gtk4::ListItem>()
             .expect("failed casting to ListItem");
 
+        unregister_bound_row(item.position());
         item.set_child(None::<&gtk4::Widget>);
     });
 
@@ -820,6 +1028,43 @@ fn setup_list_behavior(ui: &WindowData) {
                 }
             }
         });
+
+        // After create_item has set the row widget, register it for
+        // multi-select CSS repainting. The factory may recycle widgets at
+        // different positions while scrolling — connect_unbind drops the
+        // stale entry, so the map only ever holds currently-bound rows.
+        if let Some(child) = item.child()
+            && let Ok(itembox) = child.downcast::<gtk4::Box>()
+        {
+            register_bound_row(item.position(), &itembox);
+
+            // ctrl+left-click toggles multi-select for this row instead of
+            // activating it. Plain click falls through to the existing
+            // single-click-activate path on the list view. We capture
+            // ctrl+click in the Capture phase and mark the gesture
+            // CLAIMED so the ListView's activation doesn't fire.
+            if !get_config().disable_mouse {
+                let gc = GestureClick::new();
+                gc.set_button(gdk::BUTTON_PRIMARY);
+                gc.set_propagation_phase(PropagationPhase::Capture);
+                let item_ref = item.clone();
+                gc.connect_pressed(move |gesture, _n_press, _x, _y| {
+                    let evt = match gesture.current_event() {
+                        Some(e) => e,
+                        None => return,
+                    };
+                    let m = evt.modifier_state() & !ModifierType::LOCK_MASK;
+                    if !m.contains(ModifierType::CONTROL_MASK) {
+                        return;
+                    }
+                    let pos = item_ref.position();
+                    multi_selected_toggle(pos);
+                    refresh_multi_select_styling();
+                    gesture.set_state(gtk4::EventSequenceState::Claimed);
+                });
+                itembox.add_controller(gc);
+            }
+        }
     });
 
     ui.list.set_model(Some(&ui.selection));
@@ -870,6 +1115,7 @@ fn reset_provider_states() {
 
 pub fn quit(app: &Application, cancelled: bool) {
     reset_provider_states();
+    multi_selected_clear();
 
     if GLOBAL_DMENU_SENDER.read().unwrap().is_some() {
         send_message("CNCLD".to_string());
@@ -1513,6 +1759,8 @@ pub fn show_actions_menu(response: Option<crate::protos::generated_proto::query:
     let Some(item) = response.item.as_ref() else {
         return;
     };
+
+    multi_selected_clear();
 
     with_window(move |w| {
         if let Some(p) = &w.preview_container {


### PR DESCRIPTION
## Summary
- Adds a `multi_selected: BTreeSet<u32>` parallel to the single-row highlight cursor — independent state, persists across navigation, resets on query change
- Return now activates every selected row in order (50ms between elephant Activate calls; KeepOpen honored if any iter requests it). Empty selection preserves the existing "fire the highlighted row" behavior
- New configurable bindings: `%SELECT_TOGGLE_CURRENT%` (default Space), `%SELECT_EXTEND_UP%` (Shift+Up), `%SELECT_EXTEND_DOWN%` (Shift+Down); Ctrl+left-click toggles on the clicked row
- Visual: `.item-box.selected-multi` (3px left border + tint) with an override for the highlighted-and-multi-selected combo

## Implementation notes
- ListView row recycling handled via a thread-local `BOUND_ROWS` registry filled in `connect_bind` / drained in `connect_unbind`; `refresh_multi_select_styling` only walks visible widgets
- Selection cleared on `input_changed`, `quit`, and after a multi-activation completes
- No elephant protocol changes — multi-select fires N existing Activate calls

## Test plan
- [ ] Open walker, type a query that returns multiple rows
- [ ] Navigate with arrows — highlight moves, nothing else
- [ ] Press Space — current row gets the multi-select border
- [ ] Shift+Down twice — three rows now marked
- [ ] Press Return — each marked row's default action fires (open URL for websearch, etc.); launcher closes (or stays open per any KeepOpen)
- [ ] With no rows marked, Return still fires only the highlighted row
- [ ] Ctrl+left-click on a row toggles its mark without activating
- [ ] Type into the search field — selection set clears
- [ ] Space in a query that contains a literal space: confirms the known caveat — Space toggles select, so users with space-containing queries need to rebind `select_toggle_current`

## Caveats (called out in the implementation report)
- Default `select_toggle_current = ["space"]` will intercept space in the search input. Documented in `resources/config.toml`; rebind via user config to avoid.
- `Page Up`/`Page Down` aren't multi-aware (no Shift+PgDn range-select). Out of scope.
- Grid-mode `Shift+Up/Down` falls back to list-style prev/next (moves by 1, not by a column). List mode is the primary target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)