### PR TITLE
fix(providers): non-ASCII absolute icon paths render as images

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -164,7 +164,14 @@ pub fn shared_image_transformer(b: &Builder, _: &ListItem, item: &Item) {
     if let Some(image) = b.object::<Label>("ItemImageFont") {
         image.set_visible(false);
 
-        if !item.icon.is_ascii() {
+        // A non-ASCII string is *not* a reliable signal that the value is a
+        // glyph/text icon — absolute file paths can legitimately contain
+        // diacritics or non-Latin characters (e.g.
+        // `/home/user/.../walker_lang_cz_č.png`). Treat the value as a text
+        // icon only when it is *not* an absolute path AND not ASCII; the
+        // absolute-path branch lower in this function will load it as a
+        // file image. See https://github.com/abenz1267/walker/issues/696
+        if !item.icon.is_ascii() && !Path::new(&item.icon).is_absolute() {
             image.set_text(&item.icon);
             image.set_visible(true);
             is_text = true;


### PR DESCRIPTION
Closes #696.

## Problem

\`shared_image_transformer\` uses \`!item.icon.is_ascii()\` as the signal that the value is a glyph/text icon. That rule misclassifies legitimate absolute icon paths whose filenames contain diacritics or non-Latin characters — for example \`/home/user/.local/share/applications/icons/walker_lang_cz_č.png\`. The misclassification flips \`is_text = true\` and the file-loading branch a few lines below short-circuits, so the icon never renders.

The OP confirmed the behavior across many languages (German \`ä\`/\`ß\`, Polish \`ł\`/\`ż\`, French, Spanish, Turkish, Czech, Russian, Japanese — all broken when in an absolute path; ASCII absolute paths and theme-icon names unaffected).

## Fix

Add an absolute-path guard: only treat the value as a text icon when it is non-ASCII **and** not an absolute path. The existing absolute-path branch lower in the function (\`Path::new(&item.icon).is_absolute()\` -> file image) then handles these the same way it already handles ASCII absolute paths.

\`\`\`rust
- if !item.icon.is_ascii() {
+ if !item.icon.is_ascii() && !Path::new(&item.icon).is_absolute() {
\`\`\`

\`Path\` is already imported. One-line semantic change with a comment explaining the rationale. No behavior change for ASCII paths or for relative theme-icon names.

## Local verification

I don't have a GTK4 + Wayland environment locally (macOS), so I couldn't smoke-test rendering end-to-end. The diff is intentionally small and the logic change is straightforward; happy to add tighter tests if there's a suitable place in the existing suite. Walker's CI should catch any compilation regression.