### PR TITLE
fix(preview): strip `file://` scheme in preview_file()

### DIFF
--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -202,6 +202,10 @@ impl PreviewWidget {
     }
 
     pub fn preview_file(&mut self, file_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+        // Providers (e.g. the clipboard) may hand us a `file://` URI rather than a
+        // plain path; strip the scheme so Path::exists()/mime detection/drag source
+        // all operate on a real filesystem path.
+        let file_path = file_path.strip_prefix("file://").unwrap_or(file_path);
         self.current_content = format!("file{}", file_path);
         self.clear_preview();
 


### PR DESCRIPTION
Fixes #731.

### Problem

Clipboard image entries whose preview is a `file://` URI render a **blank** preview. `elephant-clipboard` emits a `file://` URI for entries copied as a *file* (image from a file manager, or a GNOME-style screenshot-to-clipboard tool that advertises `x-special/gnome-copied-files` / `text/uri-list`), while image-*data* copies arrive as bare paths.

`preview_file()` passed the raw string to `Path::new(file_path).exists()`, which is always `false` for a `"file://…"` string, so it returned early and rendered nothing. `is_absolute()` and `new_mime_guess::from_path()` were affected the same way.

### Fix

Strip a leading `file://` at the top of `preview_file()` so `exists()`, mime detection and the drag source all operate on a real filesystem path. Bare-path entries are unaffected (`strip_prefix` returns `None` → original string).

```rust
let file_path = file_path.strip_prefix("file://").unwrap_or(file_path);
```

### Testing

Built against `master`. Reproduced before/after with:

```sh
# blank before this change, renders after:
printf 'file:///path/to/some.png\r\n' | wl-copy --type text/uri-list
walker -m clipboard   # select the image entry

# already worked, still works (bare path):
wl-copy --type image/png < /path/to/some.png
```

Verified the `file://` image entry now renders its preview, with no regression for bare-path entries. Environment: walker `master`, elephant-clipboard 2.21.0, GTK 4.22, Wayland/Hyprland.

Happy to move this to `elephant-clipboard` instead if you'd rather normalize the path at the source — this side is a small, defensive fix that also covers any other provider that hands over a `file://` URI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
