### PR TITLE
Support for `cargo deb` by adding Cargo.toml options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,10 @@ chrono-humanize = "0.2.3"
 [build-dependencies]
 protobuf-codegen = "3.4"
 protoc-bin-vendored = "3.0"
+
+
+[package.metadata.deb]
+maintainer = "Andrej Benz"
+copyright = "© copyright Andrej Benz, GPL-3.0"
+extended-description = "Multi-Purpose Launcher with a lot of features. Highly Customizable and fast."
+depends = "$auto"


### PR DESCRIPTION
https://github.com/kornelski/cargo-deb is an alternative to `cargo build` that creates deb packages for Debian's apt.

`cargo deb` works without this change, but apt complains in a few places once the resulting .deb installed. This cleans up those complaints.