### PR TITLE
feat: configurable rounded blur region (blur_corner_radius)

### DIFF
--- a/resources/config.toml
+++ b/resources/config.toml
@@ -19,6 +19,7 @@ resume_last_query = false          # open walker with the last query in place
 actions_as_menu = false            # display all possible actions in a submenu
 autoplay_videos = false            # auto-play video previews
 ext_background_effect_blur = false # request the compositor to blur behind the box-wrapper via ext-background-effect-v1 (compositor must support it)
+blur_corner_radius = 20            # corner radius of the blur region (only used when ext_background_effect_blur is true)
 
 [shell]
 exclusive_zone = -1

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,7 @@ pub struct Walker {
     pub page_jump_items: u32,
     pub autoplay_videos: bool,
     pub ext_background_effect_blur: bool,
+    pub blur_corner_radius: i32,
 }
 
 // Partial config for user overrides
@@ -108,6 +109,8 @@ struct PartialWalker {
     pub as_window: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ext_background_effect_blur: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blur_corner_radius: Option<i32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -303,6 +306,9 @@ impl Walker {
         }
         if let Some(v) = partial.ext_background_effect_blur {
             self.ext_background_effect_blur = v;
+        }
+        if let Some(v) = partial.blur_corner_radius {
+            self.blur_corner_radius = v;
         }
         if let Some(p) = partial.providers {
             self.providers.merge(p);

--- a/src/wayland_blur.rs
+++ b/src/wayland_blur.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use crate::config::get_config;
 use gdk4_wayland::prelude::WaylandSurfaceExtManual;
 use gdk4_wayland::{WaylandDisplay, WaylandSurface};
 use gtk4::prelude::*;
@@ -65,18 +66,40 @@ struct BlurContext {
     compositor: WlCompositor,
     bg_effect: ExtBackgroundEffectSurfaceV1,
     last_rect: Option<(i32, i32, i32, i32)>,
+    radius: i32,
+    last_radius: i32,
 }
 
 impl BlurContext {
     fn update_region(&mut self, rect: (i32, i32, i32, i32)) {
-        if self.last_rect == Some(rect) {
+        if self.last_rect == Some(rect) && self.last_radius == self.radius {
             return;
         }
         self.last_rect = Some(rect);
+        self.last_radius = self.radius;
 
         let region = self.compositor.create_region(&self.qh, ());
         let (x, y, w, h) = rect;
-        region.add(x, y, w.max(0), h.max(0));
+        let w = w.max(0);
+        let h = h.max(0);
+        let r = self.radius.clamp(0, w / 2).clamp(0, h / 2);
+
+        if r <= 0 {
+            region.add(x, y, w, h);
+        } else {
+            let step = 1;
+            let mut yy = 0;
+            while yy < r {
+                let d = r - yy;
+                let inset = (r as f64 - f64::from(r * r - d * d).sqrt()).round() as i32;
+                let inner_w = (w - 2 * inset).max(0);
+                region.add(x + inset, y + yy, inner_w, step);
+                region.add(x + inset, y + h - yy - step, inner_w, step);
+                yy += step;
+            }
+            region.add(x, y + r, w, (h - 2 * r).max(0));
+        }
+
         self.bg_effect.set_blur_region(Some(&region));
         region.destroy();
 
@@ -177,11 +200,15 @@ fn init_context(window: &Window) -> Result<BlurContext, String> {
 
     let _ = connection.flush();
 
+    let radius = get_config().blur_corner_radius;
+
     Ok(BlurContext {
         queue,
         qh,
         compositor,
         bg_effect,
         last_rect: None,
+        radius,
+        last_radius: 0,
     })
 }


### PR DESCRIPTION
## Summary

Adds a new `blur_corner_radius` config option. It controls the corner
radius of the `ext-background-effect-v1` blur region (used when
`ext_background_effect_blur = true`).

Previously the blur region was a single rectangle (a `wl_region` with one
rect), which did not match themes with rounded `.box-wrapper` corners —
the rectangular blur bled past the rounded corners.

## Changes

- `src/config.rs`: new `blur_corner_radius: i32` option (default `20`,
  matching the default theme's box corner radius)
- `src/wayland_blur.rs`: build the blur region from multiple small
  `wl_region` rects that approximate a rounded rectangle (1-px row steps,
  rounded inset); read the radius from the config; cache the region and
  rebuild only when size or radius changes
- `resources/config.toml`: document the new option

## Notes on design

We also explored deriving the blur radius automatically from the theme's
CSS (`border-radius` of `.box-wrapper`). However, GTK4 exposes no public
API to read a widget's *effective* border-radius, and parsing the theme
stylesheet text directly is fragile (it can't handle theme inheritance,
multi-value `border-radius`, comments, or SCSS). We therefore went with
an explicit `blur_corner_radius` config option — theme authors keep it in
sync with their theme's corner radius. If wanted, a follow-up could
special-case a value (e.g. `-1`) to mean "auto".

## Testing

- Tested on niri 26.04 (supports `ext-background-effect-v1`)
- Blur follows the box-wrapper corner radius; verified with
  `blur_corner_radius = 0`, `10`, `20` and `32`
- Region caching verified (no per-frame rebuild when unchanged)
